### PR TITLE
Kan bekreftes som behandlet kvittering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,23 @@
 sudo: false
+
 cache:
   directories:
-    - '$HOME/.m2/repository'
+  - $HOME/.m2/repository
 
 language: java
 jdk:
-  - openjdk6
-  - oraclejdk7
-  - oraclejdk8
+- openjdk6
+- oraclejdk7
+- oraclejdk8
 
+env:
+  global:
+  - secure: HZwse16DnntqzIUQxphg/rawEMk3Os5eZ3EvRakYDGqVlyZgRMUtzROMplCQmZPo0y7kirFkVOVTGstE12p4FHr6fT+CX3AQRdshm/l85JILGOMoUkFLSJ3Mgz4AqJoiMpqi13X4ihRVZOQ+wf8fMlbqbSdb+/JpeBzp+D6qiRk=
+  - secure: U2g7Z11V1CRXc/2KtC09e6mSYRiRuFKJ4snJivdfCCQtT+X7bCtMs3GA5XtHYyq1XBa7/AcgFTOGGoWHlI3iSAi96WNyKJEnza7JB+NEYwVzJOMHKfW7AYMgzfqJEH3U9DMuaSdUAPP1+4CzzB+bKxQIha28+xA97l3V15zZaes=
+
+before_install:
+- echo "<settings><servers><server><id>sonatype-oss-nexus-snapshots</id><username>\${env.SONATYPE_USER}</username><password>\${env.SONATYPE_PASS}</password></server></servers></settings>"
+  > ~/.m2/deploy-settings.xml
+
+install:
+  - mvn clean deploy -U --settings ~/.m2/deploy-settings.xml

--- a/api-client/src/main/java/no/digipost/api/MessageSender.java
+++ b/api-client/src/main/java/no/digipost/api/MessageSender.java
@@ -96,7 +96,7 @@ public class MessageSender {
 		return hentKvittering(pullRequest, null);
 	}
 
-	public EbmsApplikasjonsKvittering hentKvittering(final EbmsPullRequest pullRequest, final EbmsApplikasjonsKvittering tidligereKvitteringSomSkalBekreftes) {
+	public EbmsApplikasjonsKvittering hentKvittering(final EbmsPullRequest pullRequest, final KanBekreftesSomBehandletKvittering tidligereKvitteringSomSkalBekreftes) {
 		return meldingTemplate.sendAndReceive(uri, new PullRequestSender(pullRequest, marshaller, tidligereKvitteringSomSkalBekreftes), new ApplikasjonsKvitteringReceiver(marshaller));
 	}
 
@@ -161,7 +161,7 @@ public class MessageSender {
 		private ClientInterceptorWrapper clientInterceptorWrapper = new DoNothingClientInterceptorWrapper();
 
 		private Builder(final String endpointUri, final EbmsAktoer tekniskAvsenderId, final EbmsAktoer tekniskMottaker,
-		                final WsSecurityInterceptor wsSecurityInterceptor, final KeyStoreInfo keystoreInfo) {
+						final WsSecurityInterceptor wsSecurityInterceptor, final KeyStoreInfo keystoreInfo) {
 			this.endpointUri = endpointUri;
 			this.tekniskAvsenderId = tekniskAvsenderId;
 			this.tekniskMottaker = tekniskMottaker;
@@ -356,6 +356,7 @@ public class MessageSender {
 	public static interface ClientInterceptorWrapper {
 		ClientInterceptor wrap(ClientInterceptor clientInterceptor);
 	}
+
 	public static class DoNothingClientInterceptorWrapper implements ClientInterceptorWrapper {
 		@Override
 		public ClientInterceptor wrap(ClientInterceptor clientInterceptor) {

--- a/api-client/src/main/java/no/digipost/api/handlers/BekreftelseSender.java
+++ b/api-client/src/main/java/no/digipost/api/handlers/BekreftelseSender.java
@@ -42,7 +42,7 @@ public class BekreftelseSender extends EbmsContextAware implements WebServiceMes
 	@Override
 	public void doWithMessage(final WebServiceMessage message) throws IOException, TransformerException {
 		List<Reference> references = new ArrayList<Reference>();
-		references.add(kanBekreftesSomBehandletKvittering.getReferanse().getUnmarshaled());
+		references.add(kanBekreftesSomBehandletKvittering.getReferanseTilMeldingSomKvitteres().getUnmarshaled());
 
 		ebmsContext.addRequestStep(new AddReferencesStep(jaxb2Marshaller, kanBekreftesSomBehandletKvittering.getMeldingsId(), references));
 	}

--- a/api-client/src/main/java/no/digipost/api/handlers/BekreftelseSender.java
+++ b/api-client/src/main/java/no/digipost/api/handlers/BekreftelseSender.java
@@ -42,7 +42,7 @@ public class BekreftelseSender extends EbmsContextAware implements WebServiceMes
 	@Override
 	public void doWithMessage(final WebServiceMessage message) throws IOException, TransformerException {
 		List<Reference> references = new ArrayList<Reference>();
-		references.add(kanBekreftesSomBehandletKvittering.getReferanseTilMeldingSomKvitteres().getUnmarshaled());
+		references.add(kanBekreftesSomBehandletKvittering.getReferanseTilMeldingSomKvitteres().getUnmarshalled());
 
 		ebmsContext.addRequestStep(new AddReferencesStep(jaxb2Marshaller, kanBekreftesSomBehandletKvittering.getMeldingsId(), references));
 	}

--- a/api-client/src/main/java/no/digipost/api/handlers/PullRequestSender.java
+++ b/api-client/src/main/java/no/digipost/api/handlers/PullRequestSender.java
@@ -16,10 +16,10 @@
 package no.digipost.api.handlers;
 
 import no.digipost.api.interceptors.steps.AddReferencesStep;
-import no.digipost.api.representations.EbmsApplikasjonsKvittering;
 import no.digipost.api.representations.EbmsContext;
 import no.digipost.api.representations.EbmsProcessingStep;
 import no.digipost.api.representations.EbmsPullRequest;
+import no.digipost.api.representations.KanBekreftesSomBehandletKvittering;
 import no.digipost.api.representations.Mpc;
 import no.digipost.api.xml.Constants;
 import no.digipost.api.xml.Marshalling;
@@ -30,18 +30,20 @@ import org.springframework.ws.WebServiceMessage;
 import org.springframework.ws.client.core.WebServiceMessageCallback;
 import org.springframework.ws.soap.SoapHeaderElement;
 import org.springframework.ws.soap.SoapMessage;
+import org.w3.xmldsig.Reference;
 
 import javax.xml.transform.TransformerException;
-
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 public class PullRequestSender extends EbmsContextAware implements WebServiceMessageCallback {
 
 	private final EbmsPullRequest pullRequest;
 	private final Jaxb2Marshaller marshaller;
-	private final EbmsApplikasjonsKvittering tidligereKvitteringSomSkalBekreftes;
+	private final KanBekreftesSomBehandletKvittering tidligereKvitteringSomSkalBekreftes;
 
-	public PullRequestSender(final EbmsPullRequest pullRequest, final Jaxb2Marshaller marshaller, final EbmsApplikasjonsKvittering tidligereKvitteringSomSkalBekreftes) {
+	public PullRequestSender(final EbmsPullRequest pullRequest, final Jaxb2Marshaller marshaller, final KanBekreftesSomBehandletKvittering tidligereKvitteringSomSkalBekreftes) {
 		this.pullRequest = pullRequest;
 		this.marshaller = marshaller;
 		this.tidligereKvitteringSomSkalBekreftes = tidligereKvitteringSomSkalBekreftes;
@@ -50,7 +52,10 @@ public class PullRequestSender extends EbmsContextAware implements WebServiceMes
 	@Override
 	public void doWithMessage(final WebServiceMessage message) throws IOException, TransformerException {
 		if (tidligereKvitteringSomSkalBekreftes != null) {
-			ebmsContext.addRequestStep(new AddReferencesStep(marshaller, tidligereKvitteringSomSkalBekreftes.messageId, tidligereKvitteringSomSkalBekreftes.references));
+			List<Reference> referenceToMessageToBeConfirmed = new ArrayList<Reference>();
+			referenceToMessageToBeConfirmed.add(tidligereKvitteringSomSkalBekreftes.getReferanseTilMeldingSomKvitteres().getUnmarshalled());
+
+			ebmsContext.addRequestStep(new AddReferencesStep(marshaller, tidligereKvitteringSomSkalBekreftes.getMeldingsId(), referenceToMessageToBeConfirmed));
 		}
 
 		ebmsContext.addRequestStep(new EbmsProcessingStep() {
@@ -61,7 +66,7 @@ public class PullRequestSender extends EbmsContextAware implements WebServiceMes
 				SignalMessage signalMessage = new SignalMessage()
 						.withMessageInfo(pullRequest.createMessageInfo())
 						.withPullRequest(new PullRequest()
-										.withMpc(mpc.toString())
+								.withMpc(mpc.toString())
 						);
 				Marshalling.marshal(marshaller, ebmsMessaging, Constants.SIGNAL_MESSAGE_QNAME, signalMessage);
 			}

--- a/api-client/src/main/java/no/digipost/api/handlers/PullRequestSender.java
+++ b/api-client/src/main/java/no/digipost/api/handlers/PullRequestSender.java
@@ -65,8 +65,7 @@ public class PullRequestSender extends EbmsContextAware implements WebServiceMes
 				Mpc mpc = new Mpc(pullRequest.prioritet, pullRequest.mpcId);
 				SignalMessage signalMessage = new SignalMessage()
 						.withMessageInfo(pullRequest.createMessageInfo())
-						.withPullRequest(new PullRequest()
-								.withMpc(mpc.toString())
+						.withPullRequest(new PullRequest().withMpc(mpc.toString())
 						);
 				Marshalling.marshal(marshaller, ebmsMessaging, Constants.SIGNAL_MESSAGE_QNAME, signalMessage);
 			}

--- a/api-commons/src/main/java/no/digipost/api/representations/EbmsApplikasjonsKvittering.java
+++ b/api-commons/src/main/java/no/digipost/api/representations/EbmsApplikasjonsKvittering.java
@@ -59,7 +59,7 @@ public class EbmsApplikasjonsKvittering extends EbmsOutgoingMessage implements K
 	}
 
 	@Override
-	public KvitteringsReferanse getReferanse() {
+	public KvitteringsReferanse getReferanseTilMeldingSomKvitteres() {
 		Reference reference = references.get(0);
 		return KvitteringsReferanse.builder(reference).build();
 	}

--- a/api-commons/src/main/java/no/digipost/api/representations/EbmsApplikasjonsKvittering.java
+++ b/api-commons/src/main/java/no/digipost/api/representations/EbmsApplikasjonsKvittering.java
@@ -22,10 +22,7 @@ import java.util.List;
 
 import no.digipost.api.PMode;
 
-import no.digipost.api.xml.Marshalling;
-import org.springframework.oxm.jaxb.Jaxb2Marshaller;
 import org.springframework.util.StringUtils;
-import org.springframework.xml.transform.StringResult;
 import org.unece.cefact.namespaces.standardbusinessdocumentheader.StandardBusinessDocument;
 import org.w3.xmldsig.Reference;
 
@@ -62,9 +59,9 @@ public class EbmsApplikasjonsKvittering extends EbmsOutgoingMessage implements K
 	}
 
 	@Override
-	public Referanse getReferanse() {
+	public KvitteringsReferanse getReferanse() {
 		Reference reference = references.get(0);
-		return Referanse.builder(reference).build();
+		return KvitteringsReferanse.builder(reference).build();
 	}
 
 	public static class Builder {

--- a/api-commons/src/main/java/no/digipost/api/representations/KanBekreftesSomBehandletKvittering.java
+++ b/api-commons/src/main/java/no/digipost/api/representations/KanBekreftesSomBehandletKvittering.java
@@ -19,5 +19,5 @@ public interface KanBekreftesSomBehandletKvittering {
 
 	String getMeldingsId();
 
-	Referanse getReferanse();
+	KvitteringsReferanse getReferanse();
 }

--- a/api-commons/src/main/java/no/digipost/api/representations/KanBekreftesSomBehandletKvittering.java
+++ b/api-commons/src/main/java/no/digipost/api/representations/KanBekreftesSomBehandletKvittering.java
@@ -19,5 +19,5 @@ public interface KanBekreftesSomBehandletKvittering {
 
 	String getMeldingsId();
 
-	KvitteringsReferanse getReferanse();
+	KvitteringsReferanse getReferanseTilMeldingSomKvitteres();
 }

--- a/api-commons/src/main/java/no/digipost/api/representations/KvitteringsReferanse.java
+++ b/api-commons/src/main/java/no/digipost/api/representations/KvitteringsReferanse.java
@@ -25,38 +25,37 @@ import java.io.StringReader;
 
 public class KvitteringsReferanse {
 
-	private final String marshaled;
+	private final String marshalled;
 	private final Jaxb2Marshaller marshallerSingleton = Marshalling.getMarshallerSingleton();
 
-	public String getMarshaled() {
-		return marshaled;
+	public String getMarshalled() {
+		return marshalled;
 	}
 
-	public Reference getUnmarshaled() {
-		return (Reference) marshallerSingleton.unmarshal(new StreamSource(new StringReader(marshaled)));
+	public Reference getUnmarshalled() {
+		return (Reference) marshallerSingleton.unmarshal(new StreamSource(new StringReader(marshalled)));
 	}
 
 	private KvitteringsReferanse(Reference reference) {
-		StringResult marshaledReference = new StringResult();
+		StringResult marshalledReference = new StringResult();
 
 		Jaxb2Marshaller marshallerSingleton = Marshalling.getMarshallerSingleton();
-		Marshalling.marshal(marshallerSingleton, reference, marshaledReference);
+		Marshalling.marshal(marshallerSingleton, reference, marshalledReference);
 
-		this.marshaled = marshaledReference.toString();
+		this.marshalled = marshalledReference.toString();
 	}
 
-	private KvitteringsReferanse(String marshaledReference) {
-		marshaled = marshaledReference;
+	private KvitteringsReferanse(String marshalledReference) {
+		marshalled = marshalledReference;
 	}
 
 	public static Builder builder(Reference reference) {
 		return new Builder(reference);
 	}
 
-	public static Builder builder(String marshaledReference) {
-		return new Builder(marshaledReference);
+	public static Builder builder(String marshalledReference) {
+		return new Builder(marshalledReference);
 	}
-
 
 	public static class Builder {
 		private KvitteringsReferanse target;
@@ -66,8 +65,8 @@ public class KvitteringsReferanse {
 			this.target = new KvitteringsReferanse(reference);
 		}
 
-		private Builder(String marshaledReference){
-			this.target = new KvitteringsReferanse(marshaledReference);
+		private Builder(String marshalledReference) {
+			this.target = new KvitteringsReferanse(marshalledReference);
 		}
 
 		public KvitteringsReferanse build() {

--- a/api-commons/src/main/java/no/digipost/api/representations/KvitteringsReferanse.java
+++ b/api-commons/src/main/java/no/digipost/api/representations/KvitteringsReferanse.java
@@ -45,9 +45,18 @@ public class KvitteringsReferanse {
 		this.marshaled = marshaledReference.toString();
 	}
 
+	private KvitteringsReferanse(String marshaledReference) {
+		marshaled = marshaledReference;
+	}
+
 	public static Builder builder(Reference reference) {
 		return new Builder(reference);
 	}
+
+	public static Builder builder(String marshaledReference) {
+		return new Builder(marshaledReference);
+	}
+
 
 	public static class Builder {
 		private KvitteringsReferanse target;
@@ -57,9 +66,13 @@ public class KvitteringsReferanse {
 			this.target = new KvitteringsReferanse(reference);
 		}
 
+		private Builder(String marshaledReference){
+			this.target = new KvitteringsReferanse(marshaledReference);
+		}
+
 		public KvitteringsReferanse build() {
 			if (built) {
-				throw new IllegalStateException("Can't build twice");
+				throw new IllegalStateException("Kan ikke bygges flere ganger.");
 			}
 			built = true;
 			return target;

--- a/api-commons/src/main/java/no/digipost/api/representations/KvitteringsReferanse.java
+++ b/api-commons/src/main/java/no/digipost/api/representations/KvitteringsReferanse.java
@@ -23,7 +23,7 @@ import org.w3.xmldsig.Reference;
 import javax.xml.transform.stream.StreamSource;
 import java.io.StringReader;
 
-public class Referanse {
+public class KvitteringsReferanse {
 
 	private final String marshaled;
 	private final Jaxb2Marshaller marshallerSingleton = Marshalling.getMarshallerSingleton();
@@ -36,7 +36,7 @@ public class Referanse {
 		return (Reference) marshallerSingleton.unmarshal(new StreamSource(new StringReader(marshaled)));
 	}
 
-	private Referanse(Reference reference) {
+	private KvitteringsReferanse(Reference reference) {
 		StringResult marshaledReference = new StringResult();
 
 		Jaxb2Marshaller marshallerSingleton = Marshalling.getMarshallerSingleton();
@@ -50,14 +50,14 @@ public class Referanse {
 	}
 
 	public static class Builder {
-		private Referanse target;
+		private KvitteringsReferanse target;
 		private boolean built = false;
 
 		private Builder(Reference reference) {
-			this.target = new Referanse(reference);
+			this.target = new KvitteringsReferanse(reference);
 		}
 
-		public Referanse build() {
+		public KvitteringsReferanse build() {
 			if (built) {
 				throw new IllegalStateException("Can't build twice");
 			}

--- a/api-commons/src/test/java/no/digipost/api/representations/EbmsApplikasjonsKvitteringTest.java
+++ b/api-commons/src/test/java/no/digipost/api/representations/EbmsApplikasjonsKvitteringTest.java
@@ -37,7 +37,7 @@ public class EbmsApplikasjonsKvitteringTest {
 	public void testGetReferanse() throws Exception {
 		EbmsApplikasjonsKvittering ebmsApplikasjonskvittering = getEbmsApplikasjonskvittering();
 
-		assertThat(ebmsApplikasjonskvittering.getReferanse()).isNotNull();
+		assertThat(ebmsApplikasjonskvittering.getReferanseTilMeldingSomKvitteres()).isNotNull();
 	}
 
 	private EbmsApplikasjonsKvittering getEbmsApplikasjonskvittering() {

--- a/api-commons/src/test/java/no/digipost/api/representations/EbmsApplikasjonsKvitteringTest.java
+++ b/api-commons/src/test/java/no/digipost/api/representations/EbmsApplikasjonsKvitteringTest.java
@@ -15,6 +15,7 @@
  */
 package no.digipost.api.representations;
 
+import org.fest.assertions.core.Condition;
 import org.junit.Test;
 import org.w3.xmldsig.Reference;
 
@@ -34,10 +35,19 @@ public class EbmsApplikasjonsKvitteringTest {
 	}
 
 	@Test
-	public void testGetReferanse() throws Exception {
-		EbmsApplikasjonsKvittering ebmsApplikasjonskvittering = getEbmsApplikasjonskvittering();
+	public void testGetReferanseTilMeldingSomKvitteres() throws Exception {
+		KvitteringsReferanse referanseTilMeldingSomKvitteres = getEbmsApplikasjonskvittering().getReferanseTilMeldingSomKvitteres();
 
-		assertThat(ebmsApplikasjonskvittering.getReferanseTilMeldingSomKvitteres()).isNotNull();
+		assertThat(referanseTilMeldingSomKvitteres.getMarshalled()).has(lengthGreaterThan(500));
+	}
+
+	private Condition<String> lengthGreaterThan(final int length) {
+		return new Condition<String>() {
+			@Override
+			public boolean matches(String s) {
+				return s.length() > length;
+			}
+		};
 	}
 
 	private EbmsApplikasjonsKvittering getEbmsApplikasjonskvittering() {

--- a/api-commons/src/test/java/no/digipost/api/representations/KvitteringsReferanseTest.java
+++ b/api-commons/src/test/java/no/digipost/api/representations/KvitteringsReferanseTest.java
@@ -28,24 +28,24 @@ public class KvitteringsReferanseTest {
 
 		KvitteringsReferanse kvitteringsReferanse = KvitteringsReferanse.builder(referenceToOriginalMessage).build();
 
-		assertThat(kvitteringsReferanse.getMarshaled()).isNotNull();
+		assertThat(kvitteringsReferanse.getMarshalled()).isNotNull();
 	}
 
 	@Test
-	public void testBuilder_FromMarshaledReference() throws Exception {
-		String marshaledReferenceToOriginalMessage = KvitteringsReferanse.builder(ObjectMother.getReference()).build().getMarshaled();
+	public void testBuilder_FrommarshalledReference() throws Exception {
+		String marshalledReferenceToOriginalMessage = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><ns5:Reference xmlns:ns5=\"http://www.w3.org/2000/09/xmldsig#\" URI=\"#id-f2ecf3b2-101e-433b-a30d-65a9b6779b5a\" xmlns:ns2=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:ns3=\"http://www.unece.org/cefact/namespaces/StandardBusinessDocumentHeader\" xmlns:ns4=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:ns6=\"http://docs.oasis-open.org/ebxml-msg/ebms/v3.0/ns/core/200704/\" xmlns:ns7=\"http://docs.oasis-open.org/ebxml-bp/ebbp-signals-2.0\" xmlns:ns8=\"http://www.w3.org/1999/xlink\" xmlns:ns9=\"http://begrep.difi.no/sdp/schema_v10\" xmlns:ns10=\"http://uri.etsi.org/2918/v1.2.1#\" xmlns:ns11=\"http://uri.etsi.org/01903/v1.3.2#\"><ns5:DigestMethod Algorithm=\"http://www.w3.org/2001/04/xmlenc#sha256\"/><ns5:DigestValue>eFFiS1V0dUVHU3JzZ1pzU0FUNXJGKy95ZmxyK2hsMmNVQzRjS3lpTXhSTT0=</ns5:DigestValue></ns5:Reference>";
 
-		KvitteringsReferanse kvitteringsReferanse = KvitteringsReferanse.builder(marshaledReferenceToOriginalMessage).build();
+		KvitteringsReferanse kvitteringsReferanse = KvitteringsReferanse.builder(marshalledReferenceToOriginalMessage).build();
 
-		assertThat(kvitteringsReferanse.getMarshaled()).isEqualTo(marshaledReferenceToOriginalMessage);
+		assertThat(kvitteringsReferanse.getMarshalled()).isEqualTo(marshalledReferenceToOriginalMessage);
 	}
 
 	@Test
-	public void testGetUnmarshaled() {
+	public void testGetUnmarshalled() {
 		Reference referenceToOriginalMessage = ObjectMother.getReference();
 
 		KvitteringsReferanse kvitteringsReferanse = KvitteringsReferanse.builder(referenceToOriginalMessage).build();
 
-		assertThat(kvitteringsReferanse.getUnmarshaled()).isEqualTo(referenceToOriginalMessage);
+		assertThat(kvitteringsReferanse.getUnmarshalled()).isEqualTo(referenceToOriginalMessage);
 	}
 }

--- a/api-commons/src/test/java/no/digipost/api/representations/KvitteringsReferanseTest.java
+++ b/api-commons/src/test/java/no/digipost/api/representations/KvitteringsReferanseTest.java
@@ -20,11 +20,11 @@ import org.w3.xmldsig.Reference;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 
-public class ReferanseTest {
+public class KvitteringsReferanseTest {
 
 	@Test
 	public void testBuilder() throws Exception {
-		Referanse referanse = Referanse.builder(ObjectMother.getReference()).build();
+		KvitteringsReferanse referanse = KvitteringsReferanse.builder(ObjectMother.getReference()).build();
 
 		assertThat(referanse.getMarshaled()).isNotNull();
 	}
@@ -32,7 +32,7 @@ public class ReferanseTest {
 	@Test
 	public void testGetUnmarshaled() {
 		Reference reference = ObjectMother.getReference();
-		Referanse referanse = Referanse.builder(reference).build();
+		KvitteringsReferanse referanse = KvitteringsReferanse.builder(reference).build();
 
 		assertThat(referanse.getUnmarshaled()).isEqualTo(reference);
 	}

--- a/api-commons/src/test/java/no/digipost/api/representations/KvitteringsReferanseTest.java
+++ b/api-commons/src/test/java/no/digipost/api/representations/KvitteringsReferanseTest.java
@@ -23,17 +23,29 @@ import static org.fest.assertions.api.Assertions.assertThat;
 public class KvitteringsReferanseTest {
 
 	@Test
-	public void testBuilder() throws Exception {
-		KvitteringsReferanse referanse = KvitteringsReferanse.builder(ObjectMother.getReference()).build();
+	public void testBuilder_FromReference() throws Exception {
+		Reference referenceToOriginalMessage = ObjectMother.getReference();
 
-		assertThat(referanse.getMarshaled()).isNotNull();
+		KvitteringsReferanse kvitteringsReferanse = KvitteringsReferanse.builder(referenceToOriginalMessage).build();
+
+		assertThat(kvitteringsReferanse.getMarshaled()).isNotNull();
+	}
+
+	@Test
+	public void testBuilder_FromMarshaledReference() throws Exception {
+		String marshaledReferenceToOriginalMessage = KvitteringsReferanse.builder(ObjectMother.getReference()).build().getMarshaled();
+
+		KvitteringsReferanse kvitteringsReferanse = KvitteringsReferanse.builder(marshaledReferenceToOriginalMessage).build();
+
+		assertThat(kvitteringsReferanse.getMarshaled()).isEqualTo(marshaledReferenceToOriginalMessage);
 	}
 
 	@Test
 	public void testGetUnmarshaled() {
-		Reference reference = ObjectMother.getReference();
-		KvitteringsReferanse referanse = KvitteringsReferanse.builder(reference).build();
+		Reference referenceToOriginalMessage = ObjectMother.getReference();
 
-		assertThat(referanse.getUnmarshaled()).isEqualTo(reference);
+		KvitteringsReferanse kvitteringsReferanse = KvitteringsReferanse.builder(referenceToOriginalMessage).build();
+
+		assertThat(kvitteringsReferanse.getUnmarshaled()).isEqualTo(referenceToOriginalMessage);
 	}
 }

--- a/api-commons/src/test/java/no/digipost/api/representations/ObjectMother.java
+++ b/api-commons/src/test/java/no/digipost/api/representations/ObjectMother.java
@@ -22,7 +22,7 @@ import org.w3.xmldsig.Transform;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ObjectMother {
+class ObjectMother {
 
 	public static Reference getReference() {
 		Reference reference = new Reference();


### PR DESCRIPTION
Includes merge of previous feature and a bit of naming-refactoring, as well as use of interface `KanBekreftesSomBehandletKvittering` when confirming with `bekreftForrige`