### PR TITLE
I messagesender så exponeras nu validateAfterInactivity i buildern

### DIFF
--- a/api-client/src/main/java/no/digipost/api/MessageSender.java
+++ b/api-client/src/main/java/no/digipost/api/MessageSender.java
@@ -110,6 +110,7 @@ public interface MessageSender {
         private int socketTimeout = 30000;
         private int connectTimeout = 10000;
         private int connectionRequestTimeout = 10000;
+        private int validateAfterInactivity = 2000;
         private SoapLog.LogLevel logLevel = LogLevel.NONE;
         private ClientInterceptorWrapper clientInterceptorWrapper = interceptor -> interceptor;
 
@@ -164,6 +165,11 @@ public interface MessageSender {
 
         public Builder withMeldingInterceptorBefore(final Class<?> clazz, final ClientInterceptor interceptor) {
             interceptorBefore.add(new InsertInterceptor(clazz, interceptor));
+            return this;
+        }
+
+        public Builder withValidateAfterInactivity(final int validateAfterInactivity) {
+            this.validateAfterInactivity = validateAfterInactivity;
             return this;
         }
 
@@ -271,6 +277,7 @@ public interface MessageSender {
 
         private HttpComponentsMessageSender getHttpComponentsMessageSender() {
             PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
+            connectionManager.setValidateAfterInactivity(validateAfterInactivity);
             connectionManager.setMaxTotal(maxTotal);
             connectionManager.setDefaultMaxPerRoute(defaultMaxPerRoute);
 

--- a/xsd/src/test/java/no/digipost/xsd/jaxb/XSAdaptersTest.java
+++ b/xsd/src/test/java/no/digipost/xsd/jaxb/XSAdaptersTest.java
@@ -22,9 +22,13 @@ public class XSAdaptersTest {
 
     @Test
     public void unmarshall_yields_datetime_with_region_based_zoneId_replaced_with_GMT_offset() {
-        ZonedDateTime rightNowInAmerica = ZonedDateTime.now(ZoneId.of("America/New_York"));
+        ZoneId newYorkZone = ZoneId.of("America/New_York");
+        ZonedDateTime rightNowInAmerica = ZonedDateTime.now(newYorkZone);
         String xmlDateTimeString = dateTimeAdapter.marshal(rightNowInAmerica);
-        assertThat(dateTimeAdapter.unmarshal(xmlDateTimeString), is(rightNowInAmerica.withZoneSameInstant(ZoneId.of("GMT-5"))));
+        
+        boolean daylightSavings = newYorkZone.getRules().isDaylightSavings(rightNowInAmerica.toInstant());
+        ZoneId gmtZone = daylightSavings ? ZoneId.of("GMT-4") : ZoneId.of("GMT-5");
+        assertThat(dateTimeAdapter.unmarshal(xmlDateTimeString), is(rightNowInAmerica.withZoneSameInstant(gmtZone)));
     }
 
     @Test


### PR DESCRIPTION
fixade också ett test som failade när new york gick över i sommartid