### PR TITLE
Bump wss4j.version from 2.1.8 to 2.2.2 (#33)

### DIFF
--- a/api-client/NOTICE
+++ b/api-client/NOTICE
@@ -26,7 +26,6 @@ This software includes third party software subject to the following licenses:
   Hamcrest Library under BSD Licence 3
   JASYPT: Java Simplified Encryption under The Apache Software License, Version 2.0
   java-support under The Apache Software License, Version 2.0
-  JavaMail 1.4 under The Apache Software License, Version 2.0
   JavaMail API under CDDL/GPLv2+CE
   javax.xml.soap API under CDDL + GPLv2 with classpath exception
   JAXB2 Basics - Runtime under BSD-Style License
@@ -72,6 +71,4 @@ This software includes third party software subject to the following licenses:
   spring-ws-core under Apache License, Version 2.0
   spring-ws-security under Apache License, Version 2.0
   spring-xml under Apache License, Version 2.0
-  Stax2 API under The BSD License
-  Woodstox under The Apache Software License, Version 2.0
 

--- a/api-commons/NOTICE
+++ b/api-commons/NOTICE
@@ -25,7 +25,6 @@ This software includes third party software subject to the following licenses:
   Hamcrest Library under BSD Licence 3
   JASYPT: Java Simplified Encryption under The Apache Software License, Version 2.0
   java-support under The Apache Software License, Version 2.0
-  JavaMail 1.4 under The Apache Software License, Version 2.0
   JavaMail API under CDDL/GPLv2+CE
   JAXB2 Basics - Runtime under BSD-Style License
   jaxen under The BSD 3-Clause License
@@ -65,6 +64,4 @@ This software includes third party software subject to the following licenses:
   spring-ws-core under Apache License, Version 2.0
   spring-ws-security under Apache License, Version 2.0
   spring-xml under Apache License, Version 2.0
-  Stax2 API under The BSD License
-  Woodstox under The Apache Software License, Version 2.0
 

--- a/api-commons/src/main/java/no/digipost/api/interceptors/Wss4jInterceptor.java
+++ b/api-commons/src/main/java/no/digipost/api/interceptors/Wss4jInterceptor.java
@@ -312,7 +312,6 @@ public class Wss4jInterceptor extends AbstractWsSecurityInterceptor {
             //algorithmSuite.addTransformAlgorithm("http://www.w3.org/2001/10/xml-exc-c14n#");
             //algorithmSuite.addTransformAlgorithm("http://docs.oasis-open.org/wss/2004/XX/oasis-2004XX-wss-swa-profile-1.0#Attachment-Complete-Transform");
             requestData.setAlgorithmSuite(algorithmSuite);
-            requestData.setEnableTimestampReplayCache(false);
 
 
             WSHandlerResult handlerResult = securityEngine.processSecurityHeader(envelopeAsDocument, requestData);

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <spring.version>5.1.5.RELEASE</spring.version>
         <spring.ws.version>3.0.6.RELEASE</spring.ws.version>
         <spring.security.version>5.1.4.RELEASE</spring.security.version>
-        <wss4j.version>2.1.8</wss4j.version>
+        <wss4j.version>2.2.2</wss4j.version>
         <hamcrest.version>2.1</hamcrest.version>
         <jaxb2-basics.version>0.12.0</jaxb2-basics.version>
     </properties>
@@ -232,6 +232,18 @@
                     <exclusion>
                         <groupId>javax.xml.stream</groupId>
                         <artifactId>stax-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.dropwizard.metrics</groupId>
+                        <artifactId>metrics-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.woodstox</groupId>
+                        <artifactId>woodstox-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.geronimo.javamail</groupId>
+                        <artifactId>geronimo-javamail_1.4_mail</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>


### PR DESCRIPTION
* Bump wss4j.version from 2.1.8 to 2.2.2

Bumps `wss4j.version` from 2.1.8 to 2.2.2.

Updates `wss4j-ws-security-dom` from 2.1.8 to 2.2.2

Updates `wss4j-ws-security-common` from 2.1.8 to 2.2.2

Signed-off-by: dependabot[bot] <support@dependabot.com>

* Fix dependency update problems manually

Update notice
Remove invalid statement (the functionality should be the same, as the value we were setting is the default)
Exclude transative dependencies from wss4j-ws-security-common that we don't need