### PR TITLE
Remove Jaxen and OpenSAML, upgrade Spring Security

### DIFF
--- a/api-client/NOTICE
+++ b/api-client/NOTICE
@@ -16,14 +16,9 @@ This software includes third party software subject to the following licenses:
   Apache WSS4J WS-Security Common under The Apache Software License, Version 2.0
   Apache XML Security for Java under The Apache Software License, Version 2.0
   Bouncy Castle Provider under Bouncy Castle Licence
-  Byte Buddy (without dependencies) under The Apache Software License, Version 2.0
-  Byte Buddy Java agent under The Apache Software License, Version 2.0
   Cryptacular Library under Apache 2 or GNU Lesser General Public License
   Extended StAX API under Eclipse Distribution License - v 1.0
   Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
-  Hamcrest under BSD Licence 3
-  Hamcrest Core under BSD Licence 3
-  Hamcrest Library under BSD Licence 3
   jakarta.xml.bind-api under Eclipse Distribution License - v 1.0
   jakarta.xml.soap API under Eclipse Distribution License - v 1.0
   JASYPT: Java Simplified Encryption under The Apache Software License, Version 2.0
@@ -35,11 +30,8 @@ This software includes third party software subject to the following licenses:
   JCL 1.2 implemented over SLF4J under MIT License
   Joda-Time under Apache 2
   JUL to SLF4J bridge under MIT License
-  JUnit under Eclipse Public License 1.0
   Log4j Implemented Over SLF4J under Apache Software Licenses
   MIME streaming extension under Eclipse Distribution License - v 1.0
-  mockito-core under The MIT License
-  Objenesis under Apache 2
   OpenSAML :: Core under The Apache Software License, Version 2.0
   OpenSAML :: Profile API under The Apache Software License, Version 2.0
   OpenSAML :: SAML Provider API under The Apache Software License, Version 2.0
@@ -54,11 +46,9 @@ This software includes third party software subject to the following licenses:
   OpenSAML :: XML Security API under The Apache Software License, Version 2.0
   OpenSAML :: XML Security Implementation under The Apache Software License, Version 2.0
   saaj-impl under Eclipse Distribution License - v 1.0
-  SDP Shared - API Client under The Apache Software License, Version 2.0
   SDP Shared - API Commons under The Apache Software License, Version 2.0
   SDP Shared - XSD & JAXB under The Apache Software License, Version 2.0
   SLF4J API Module under MIT License
-  SLF4J Simple Binding under MIT License
   Spring AOP under Apache License, Version 2.0
   Spring Beans under Apache License, Version 2.0
   Spring Commons Logging Bridge under Apache License, Version 2.0

--- a/api-client/NOTICE
+++ b/api-client/NOTICE
@@ -26,7 +26,6 @@ This software includes third party software subject to the following licenses:
   JavaBeans Activation Framework API jar under EDL 1.0
   JavaMail API under CDDL/GPLv2+CE
   JAXB2 Basics - Runtime under BSD-Style License
-  jaxen under The BSD 3-Clause License
   JCL 1.2 implemented over SLF4J under MIT License
   Joda-Time under Apache 2
   JUL to SLF4J bridge under MIT License

--- a/api-client/NOTICE
+++ b/api-client/NOTICE
@@ -24,7 +24,6 @@ This software includes third party software subject to the following licenses:
   JASYPT: Java Simplified Encryption under The Apache Software License, Version 2.0
   java-support under The Apache Software License, Version 2.0
   JavaBeans Activation Framework API jar under EDL 1.0
-  JavaMail API under CDDL/GPLv2+CE
   JAXB2 Basics - Runtime under BSD-Style License
   JCL 1.2 implemented over SLF4J under MIT License
   Joda-Time under Apache 2

--- a/api-client/NOTICE
+++ b/api-client/NOTICE
@@ -16,33 +16,16 @@ This software includes third party software subject to the following licenses:
   Apache WSS4J WS-Security Common under The Apache Software License, Version 2.0
   Apache XML Security for Java under The Apache Software License, Version 2.0
   Bouncy Castle Provider under Bouncy Castle Licence
-  Cryptacular Library under Apache 2 or GNU Lesser General Public License
   Extended StAX API under Eclipse Distribution License - v 1.0
-  Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
   jakarta.xml.bind-api under Eclipse Distribution License - v 1.0
   jakarta.xml.soap API under Eclipse Distribution License - v 1.0
   JASYPT: Java Simplified Encryption under The Apache Software License, Version 2.0
-  java-support under The Apache Software License, Version 2.0
   JavaBeans Activation Framework API jar under EDL 1.0
   JAXB2 Basics - Runtime under BSD-Style License
   JCL 1.2 implemented over SLF4J under MIT License
-  Joda-Time under Apache 2
   JUL to SLF4J bridge under MIT License
   Log4j Implemented Over SLF4J under Apache Software Licenses
   MIME streaming extension under Eclipse Distribution License - v 1.0
-  OpenSAML :: Core under The Apache Software License, Version 2.0
-  OpenSAML :: Profile API under The Apache Software License, Version 2.0
-  OpenSAML :: SAML Provider API under The Apache Software License, Version 2.0
-  OpenSAML :: SAML Provider Implementations under The Apache Software License, Version 2.0
-  OpenSAML :: SAML XACML Profile API under The Apache Software License, Version 2.0
-  OpenSAML :: SAML XACML Profile Implementation under The Apache Software License, Version 2.0
-  OpenSAML :: Security API under The Apache Software License, Version 2.0
-  OpenSAML :: Security Implementation under The Apache Software License, Version 2.0
-  OpenSAML :: SOAP Provider API under The Apache Software License, Version 2.0
-  OpenSAML :: XACML Provider API under The Apache Software License, Version 2.0
-  OpenSAML :: XACML Provider Implementations under The Apache Software License, Version 2.0
-  OpenSAML :: XML Security API under The Apache Software License, Version 2.0
-  OpenSAML :: XML Security Implementation under The Apache Software License, Version 2.0
   saaj-impl under Eclipse Distribution License - v 1.0
   SDP Shared - API Commons under The Apache Software License, Version 2.0
   SDP Shared - XSD & JAXB under The Apache Software License, Version 2.0

--- a/api-client/pom.xml
+++ b/api-client/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>no.digipost</groupId>
         <artifactId>sdp-shared</artifactId>
-        <version>2.9</version>
+        <version>2.10-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/api-client/pom.xml
+++ b/api-client/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>no.digipost</groupId>
         <artifactId>sdp-shared</artifactId>
-        <version>2.9-SNAPSHOT</version>
+        <version>2.9</version>
     </parent>
 
     <dependencies>

--- a/api-client/pom.xml
+++ b/api-client/pom.xml
@@ -53,12 +53,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.sun.mail</groupId>
-            <artifactId>javax.mail</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/api-client/pom.xml
+++ b/api-client/pom.xml
@@ -112,11 +112,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/api-commons/NOTICE
+++ b/api-commons/NOTICE
@@ -21,7 +21,6 @@ This software includes third party software subject to the following licenses:
   java-support under The Apache Software License, Version 2.0
   JavaMail API under CDDL/GPLv2+CE
   JAXB2 Basics - Runtime under BSD-Style License
-  jaxen under The BSD 3-Clause License
   JCL 1.2 implemented over SLF4J under MIT License
   Joda-Time under Apache 2
   OpenSAML :: Core under The Apache Software License, Version 2.0

--- a/api-commons/NOTICE
+++ b/api-commons/NOTICE
@@ -15,14 +15,8 @@ This software includes third party software subject to the following licenses:
   Apache WSS4J WS-Security Common under The Apache Software License, Version 2.0
   Apache XML Security for Java under The Apache Software License, Version 2.0
   Bouncy Castle Provider under Bouncy Castle Licence
-  Byte Buddy (without dependencies) under The Apache Software License, Version 2.0
-  Byte Buddy Java agent under The Apache Software License, Version 2.0
   Cryptacular Library under Apache 2 or GNU Lesser General Public License
-  EqualsVerifier under The Apache Software License, Version 2.0
   Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
-  Hamcrest under BSD Licence 3
-  Hamcrest Core under BSD Licence 3
-  Hamcrest Library under BSD Licence 3
   JASYPT: Java Simplified Encryption under The Apache Software License, Version 2.0
   java-support under The Apache Software License, Version 2.0
   JavaMail API under CDDL/GPLv2+CE
@@ -30,9 +24,6 @@ This software includes third party software subject to the following licenses:
   jaxen under The BSD 3-Clause License
   JCL 1.2 implemented over SLF4J under MIT License
   Joda-Time under Apache 2
-  JUnit under Eclipse Public License 1.0
-  mockito-core under The MIT License
-  Objenesis under Apache 2
   OpenSAML :: Core under The Apache Software License, Version 2.0
   OpenSAML :: Profile API under The Apache Software License, Version 2.0
   OpenSAML :: SAML Provider API under The Apache Software License, Version 2.0
@@ -46,10 +37,8 @@ This software includes third party software subject to the following licenses:
   OpenSAML :: XACML Provider Implementations under The Apache Software License, Version 2.0
   OpenSAML :: XML Security API under The Apache Software License, Version 2.0
   OpenSAML :: XML Security Implementation under The Apache Software License, Version 2.0
-  SDP Shared - API Commons under The Apache Software License, Version 2.0
   SDP Shared - XSD & JAXB under The Apache Software License, Version 2.0
   SLF4J API Module under MIT License
-  SLF4J Simple Binding under MIT License
   Spring AOP under Apache License, Version 2.0
   Spring Beans under Apache License, Version 2.0
   Spring Commons Logging Bridge under Apache License, Version 2.0

--- a/api-commons/NOTICE
+++ b/api-commons/NOTICE
@@ -15,26 +15,9 @@ This software includes third party software subject to the following licenses:
   Apache WSS4J WS-Security Common under The Apache Software License, Version 2.0
   Apache XML Security for Java under The Apache Software License, Version 2.0
   Bouncy Castle Provider under Bouncy Castle Licence
-  Cryptacular Library under Apache 2 or GNU Lesser General Public License
-  Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
   JASYPT: Java Simplified Encryption under The Apache Software License, Version 2.0
-  java-support under The Apache Software License, Version 2.0
   JAXB2 Basics - Runtime under BSD-Style License
   JCL 1.2 implemented over SLF4J under MIT License
-  Joda-Time under Apache 2
-  OpenSAML :: Core under The Apache Software License, Version 2.0
-  OpenSAML :: Profile API under The Apache Software License, Version 2.0
-  OpenSAML :: SAML Provider API under The Apache Software License, Version 2.0
-  OpenSAML :: SAML Provider Implementations under The Apache Software License, Version 2.0
-  OpenSAML :: SAML XACML Profile API under The Apache Software License, Version 2.0
-  OpenSAML :: SAML XACML Profile Implementation under The Apache Software License, Version 2.0
-  OpenSAML :: Security API under The Apache Software License, Version 2.0
-  OpenSAML :: Security Implementation under The Apache Software License, Version 2.0
-  OpenSAML :: SOAP Provider API under The Apache Software License, Version 2.0
-  OpenSAML :: XACML Provider API under The Apache Software License, Version 2.0
-  OpenSAML :: XACML Provider Implementations under The Apache Software License, Version 2.0
-  OpenSAML :: XML Security API under The Apache Software License, Version 2.0
-  OpenSAML :: XML Security Implementation under The Apache Software License, Version 2.0
   SDP Shared - XSD & JAXB under The Apache Software License, Version 2.0
   SLF4J API Module under MIT License
   Spring AOP under Apache License, Version 2.0

--- a/api-commons/NOTICE
+++ b/api-commons/NOTICE
@@ -19,7 +19,6 @@ This software includes third party software subject to the following licenses:
   Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
   JASYPT: Java Simplified Encryption under The Apache Software License, Version 2.0
   java-support under The Apache Software License, Version 2.0
-  JavaMail API under CDDL/GPLv2+CE
   JAXB2 Basics - Runtime under BSD-Style License
   JCL 1.2 implemented over SLF4J under MIT License
   Joda-Time under Apache 2

--- a/api-commons/pom.xml
+++ b/api-commons/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>no.digipost</groupId>
         <artifactId>sdp-shared</artifactId>
-        <version>2.9</version>
+        <version>2.10-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/api-commons/pom.xml
+++ b/api-commons/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>no.digipost</groupId>
         <artifactId>sdp-shared</artifactId>
-        <version>2.9-SNAPSHOT</version>
+        <version>2.9</version>
     </parent>
 
     <dependencies>

--- a/api-commons/pom.xml
+++ b/api-commons/pom.xml
@@ -19,11 +19,6 @@
             <version>${project.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>jaxen</groupId>
-            <artifactId>jaxen</artifactId>
-        </dependency>
-
         <!-- Spring WS -->
         <dependency>
             <groupId>org.springframework.ws</groupId>
@@ -129,6 +124,11 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>co.unruly</groupId>
+            <artifactId>java-8-matchers</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/api-commons/pom.xml
+++ b/api-commons/pom.xml
@@ -60,12 +60,6 @@
             <artifactId>bcprov-jdk15on</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>com.sun.mail</groupId>
-            <artifactId>javax.mail</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
         <!-- Spring -->
         <dependency>
             <groupId>org.springframework</groupId>

--- a/api-commons/pom.xml
+++ b/api-commons/pom.xml
@@ -28,6 +28,10 @@
             <groupId>org.springframework.ws</groupId>
             <artifactId>spring-xml</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.ws</groupId>
+            <artifactId>spring-ws-security</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -68,10 +72,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.ws</groupId>
-            <artifactId>spring-ws-security</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/api-commons/pom.xml
+++ b/api-commons/pom.xml
@@ -111,16 +111,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>co.unruly</groupId>
             <artifactId>java-8-matchers</artifactId>
             <scope>test</scope>

--- a/api-commons/src/main/java/no/digipost/api/EbmsReferenceExtractor.java
+++ b/api-commons/src/main/java/no/digipost/api/EbmsReferenceExtractor.java
@@ -16,6 +16,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
 import javax.xml.transform.dom.DOMSource;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -42,14 +43,14 @@ public class EbmsReferenceExtractor {
         for (String href : hrefs) {
 
             List<Node> refs = XpathUtil.getDOMXPath("//ds:Reference[@URI='" + href + "']", element);
-            if (refs.size() == 0) {
+            if (refs.isEmpty()) {
                 List<Node> parts = XpathUtil.getDOMXPath("//*[@Id='" + href.substring(1) + "']", message.getDocument().getDocumentElement());
-                if (parts.size() > 0) {
+                if (!parts.isEmpty()) {
                     String refId = parts.get(0).getAttributes().getNamedItemNS(Constants.WSSEC_UTILS_NAMESPACE, "Id").getNodeValue();
                     refs = XpathUtil.getDOMXPath("//ds:Reference[@URI='#" + refId + "']", element);
                 }
             }
-            if (refs.size() > 0) {
+            if (!refs.isEmpty()) {
                 Reference ref = Marshalling.unmarshal(jaxb2Marshaller, refs.get(0), Reference.class);
                 String name = "attachment";
                 Element elm = doc.getElementById(href.replace("#", ""));
@@ -71,7 +72,7 @@ public class EbmsReferenceExtractor {
         }
         SoapHeaderElement incomingSoapHeaderElement = soapHeaderElementIterator.next();
         Messaging messaging = (Messaging) jaxb2Marshaller.unmarshal(incomingSoapHeaderElement.getSource());
-        if (messaging.getUserMessages().size() == 0) {
+        if (messaging.getUserMessages().isEmpty()) {
             return new ArrayList<String>();
         }
         UserMessage userMessage = messaging.getUserMessages().get(0);

--- a/api-commons/src/main/java/no/digipost/api/xml/XpathUtil.java
+++ b/api-commons/src/main/java/no/digipost/api/xml/XpathUtil.java
@@ -2,31 +2,14 @@ package no.digipost.api.xml;
 
 import org.jaxen.JaxenException;
 import org.jaxen.dom.DOMXPath;
-import org.springframework.xml.xpath.Jaxp13XPathTemplate;
-import org.springframework.xml.xpath.NodeMapper;
-import org.w3c.dom.DOMException;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
-import javax.xml.transform.Source;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class XpathUtil {
-
-    private static final NodeMapper<Node> returnNode = new NodeMapper<Node>() {
-        @Override
-        public Node mapNode(final Node node, final int nodeNum) throws DOMException {
-            return node;
-        }
-    };
-
-    public static List<Node> evaluateXpath(final String expression, final Source source) {
-        Jaxp13XPathTemplate template = new Jaxp13XPathTemplate();
-        template.setNamespaces(getXpathNamespaces());
-        return template.evaluate(expression, source, returnNode);
-    }
 
     @SuppressWarnings("unchecked")
     public static List<Node> getDOMXPath(final String expression, final Element element) {

--- a/api-commons/src/main/java/no/digipost/api/xml/XpathUtil.java
+++ b/api-commons/src/main/java/no/digipost/api/xml/XpathUtil.java
@@ -1,32 +1,73 @@
 package no.digipost.api.xml;
 
-import org.jaxen.JaxenException;
-import org.jaxen.dom.DOMXPath;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.xml.namespace.NamespaceContext;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathFactory;
 
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.IntStream;
+
+import static java.util.Collections.unmodifiableMap;
+import static java.util.stream.Collectors.toList;
 
 public class XpathUtil {
 
-    @SuppressWarnings("unchecked")
     public static List<Node> getDOMXPath(final String expression, final Element element) {
         try {
-            DOMXPath xpath = new DOMXPath(expression);
-            Map<String, String> xpathNamespaces = getXpathNamespaces();
-            for (String s : xpathNamespaces.keySet()) {
-                xpath.addNamespace(s, xpathNamespaces.get(s));
-            }
-            return xpath.selectNodes(element);
-        } catch (JaxenException e) {
-            throw new RuntimeException(e);
+            XPathExpression xpathExpression = xpathFactory.newXPath().compile(expression);
+            NodeList nodes = (NodeList) xpathExpression.evaluate(element, XPathConstants.NODESET);
+            int nodesFound = nodes.getLength();
+            return IntStream.range(0, nodesFound).mapToObj(nodes::item).collect(toList());
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    "Unable to evaluate xpath '" + expression + "' on node " + element + ", " +
+                    "because " + e.getClass().getSimpleName() + ": '" + e.getMessage() + "'", e);
         }
-
     }
 
-    public static Map<String, String> getXpathNamespaces() {
+    private static final class XPathSynchronizedFactory {
+
+        private final XPathFactory xpathFactory = XPathFactory.newInstance();
+
+        synchronized XPath newXPath() {
+            XPath xpath = xpathFactory.newXPath();
+            xpath.setNamespaceContext(ebmsNamespaceContext);
+            return xpath;
+        }
+    }
+
+    private static final XPathSynchronizedFactory xpathFactory = new XPathSynchronizedFactory();
+
+
+    private static final NamespaceContext ebmsNamespaceContext = new NamespaceContext() {
+
+        @Override
+        public String getNamespaceURI(String prefix) {
+            return XPATH_NAMESPACES.get(prefix);
+        }
+
+        @Override
+        public Iterator<String> getPrefixes(String namespaceURI) {
+            throw new UnsupportedOperationException("getPrefixes() method is not supported");
+        }
+
+        @Override
+        public String getPrefix(String namespaceURI) {
+            throw new UnsupportedOperationException("getPrefix() method is not supported");
+        }
+
+    };
+
+    private static final Map<String, String> XPATH_NAMESPACES; static {
         Map<String, String> map = new HashMap<String, String>();
         map.put("env", Constants.SOAP_ENVELOPE12_NAMESPACE);
         map.put("eb", Constants.EBMS_NAMESPACE);
@@ -36,6 +77,10 @@ public class XpathUtil {
         map.put("wsu", Constants.WSSEC_UTILS_NAMESPACE);
         map.put("sbd", Constants.SBDH_NAMESPACE);
         map.put("sdp", Constants.SDP_NAMESPACE);
-        return map;
+        XPATH_NAMESPACES = unmodifiableMap(map);
+    }
+
+    public static Map<String, String> getXpathNamespaces() {
+        return XPATH_NAMESPACES;
     }
 }

--- a/api-commons/src/test/java/no/digipost/api/xml/EbmsReferenceExtractorTest.java
+++ b/api-commons/src/test/java/no/digipost/api/xml/EbmsReferenceExtractorTest.java
@@ -1,0 +1,54 @@
+package no.digipost.api.xml;
+
+import no.digipost.api.EbmsReferenceExtractor;
+import org.junit.Test;
+import org.springframework.ws.soap.saaj.SaajSoapMessage;
+import org.w3.xmldsig.DigestMethod;
+import org.w3.xmldsig.Reference;
+
+import javax.xml.soap.MessageFactory;
+import javax.xml.soap.SOAPMessage;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import static co.unruly.matchers.Java8Matchers.where;
+import static javax.xml.crypto.dsig.DigestMethod.SHA256;
+import static javax.xml.soap.SOAPConstants.SOAP_1_2_PROTOCOL;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+public class EbmsReferenceExtractorTest {
+
+    private static final byte[] FAKE_EBMS; static {
+        try {
+            FAKE_EBMS = Files.readAllBytes(Paths.get(EbmsReferenceExtractorTest.class.getResource("/fake-ebms.xml").toURI()));
+        } catch (IOException | URISyntaxException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+
+    private final EbmsReferenceExtractor referenceExtractor = new EbmsReferenceExtractor(Marshalling.getMarshallerSingleton());
+
+    @Test
+    public void extractReferencesFromEbmsSoapMessage() throws Exception {
+        SOAPMessage message = MessageFactory.newInstance(SOAP_1_2_PROTOCOL).createMessage(null, new ByteArrayInputStream(FAKE_EBMS));
+        Map<String, Reference> references = referenceExtractor.getReferences(new SaajSoapMessage(message));
+        assertThat(references.keySet(), containsInAnyOrder("body", "attachment"));
+
+        Reference soapBodyReference = references.get("body");
+        assertThat(soapBodyReference, where(Reference::getURI, is("#soapBody")));
+        assertThat(soapBodyReference, where(Reference::getDigestMethod, where(DigestMethod::getAlgorithm, is(SHA256))));
+
+        Reference dokumentpakkeReference = references.get("attachment");
+        assertThat(dokumentpakkeReference, where(Reference::getURI, containsString("meldingsformidler.sdp.difi.no")));
+        assertThat(dokumentpakkeReference, where(Reference::getDigestMethod, where(DigestMethod::getAlgorithm, is(SHA256))));
+    }
+}

--- a/api-commons/src/test/resources/fake-ebms.xml
+++ b/api-commons/src/test/resources/fake-ebms.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope">
+    <env:Header>
+        <wsse:Security env:mustUnderstand="true" xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
+            <wsse:BinarySecurityToken EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary" ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3" wsu:Id="X509-7cc8378a-6fbc-49e7-ab24-6da45f2173e2">MIIC+zCCAeOgAwIBAgIEeU6smzANBgkqhkiG9w0BAQsFADAnMSUwIwYDVQQDDBxEaWdpcG9zdCBUZXN0IENlcnQgQXV0aG9yaXR5MB4XDTE5MDQxNDIwMDc0OFoXDTE5MTAxNTIwMDc0OFowFDESMBAGA1UEAwwJMTIzNDU2Nzg5MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkWCH3+1Clb4VbCzE54SNAfTlXCOkUvvXjyBShL4mEq40ZAjJmWgF9kvY8crQEQNmi7F2bWvnr5QPbUJ5TVf5XBsqJ4sHBlmYkAmgJLgJmfGitgpRQiw6p0ilfscJf/o5VS7mur2jsJmu6mZP0YwZXrcLpk8Fy3R+/evcXwXiddruGWAJ8J7Nz+LUIWhfQYeAS/3v1dm2VB0Rg66kA4G1Z3Ccxwdd5+JeKh2xaOxRtcuKZw6vnQMxv3g4z0Cbh/TUD30sciZXCB7yZK8tsDGZbL8U18nkjOfJqbkKuUbzi8S9RYW1EjqGEXBZRH9FLoaUc6pgvMIE0oB/b0OGsEWHTQIDAQABo0IwQDAdBgNVHQ4EFgQUTcRswyDj4h9F5imwZrNxNHKyWx4wHwYDVR0jBBgwFoAUKYKJg/t4gJpxzSp0SAfVQ5q6cvMwDQYJKoZIhvcNAQELBQADggEBADMK0vurD5/b3gQVgyZdCgjv8QqEsQRhPaeKjHIFYjGMS8d2Icvso10g+UHUCjhhvN733EoRUOGvic33bxVfTOeLmp3AdbTNa57H2wIpU8ID/TbrvK7lB66XO24Gm/taeSPmU/5pQBwTNh4Dwqvv4NHQkWeDUhynDgQ+RHZ5xy2RtTtkEYETsDOtpuoh6kw9jcA8f8D8rynuitJqy3qRLwx9NAYGHQpc0NXqjW+rQJBk5MVqFfgwfqCLCOOxFu6h+Bii9LVUQCTlO5QDo1K4LyeteHjOikC3Al4t8Z8kE/dym+cAPbG3/imnDTy9zomQ69DIVwE+TxjTTZ6w9J1DPLI=</wsse:BinarySecurityToken>
+            <wsu:Timestamp wsu:Id="TS-5d29629c-3efb-4000-ab1d-8dbcc9f76424">
+                <wsu:Created>2019-04-15T20:07:51.199Z</wsu:Created>
+                <wsu:Expires>2019-04-15T20:12:51.199Z</wsu:Expires>
+            </wsu:Timestamp>
+            <ds:Signature Id="SIG-30b513ca-0b5b-4053-899e-3290056bc308" xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+                <ds:SignedInfo>
+                    <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+                        <ec:InclusiveNamespaces PrefixList="env" xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+                    </ds:CanonicalizationMethod>
+                    <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+                    <ds:Reference URI="#soapBody">
+                        <ds:Transforms>
+                            <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+                        </ds:Transforms>
+                        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+                        <ds:DigestValue>qg28Dm+fuNQR+Wumem7gH3Tc3WId3vwOXW3QfQtWRko=</ds:DigestValue>
+                    </ds:Reference>
+                    <ds:Reference URI="#TS-5d29629c-3efb-4000-ab1d-8dbcc9f76424">
+                        <ds:Transforms>
+                            <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+                                <ec:InclusiveNamespaces PrefixList="env wsse" xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+                            </ds:Transform>
+                        </ds:Transforms>
+                        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+                        <ds:DigestValue>M/qI+yxY9c7nMzUQg9f8GQA1tQb8s1CrX6ERmy9VetI=</ds:DigestValue>
+                    </ds:Reference>
+                    <ds:Reference URI="#id-e5f1258b-4535-481b-a8f4-c5170960a5d1">
+                        <ds:Transforms>
+                            <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+                        </ds:Transforms>
+                        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+                        <ds:DigestValue>C/WM++VKVIlGP70/b/BmFDDEpL2ud6Ne2LKQMrZyL/I=</ds:DigestValue>
+                    </ds:Reference>
+                    <ds:Reference URI="cid:0e1c44cf-5e09-4e9e-a8e5-7315d515b62e@meldingsformidler.sdp.difi.no">
+                        <ds:Transforms>
+                            <ds:Transform Algorithm="http://docs.oasis-open.org/wss/oasis-wss-SwAProfile-1.1#Attachment-Content-Signature-Transform"/>
+                        </ds:Transforms>
+                        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+                        <ds:DigestValue>bB3MSFw53APknzuIr5UgVolnffEcaCKWWh8aJdOBB4M=</ds:DigestValue>
+                    </ds:Reference>
+                </ds:SignedInfo>
+                <ds:SignatureValue>e05PSEaSorTL3kSRXVSgwp1hExWmFojBWu+rvnpfwzM0lMrPQYphIVqGPe7EL7IZpAYNBdBcR0x9NO9uWrJhvEYMXKLstbn30Vq1A2MWglfk2hSp+e5V0/Mn0v9YZv4s2eL1DYIfNgi43viFN/sbsWhbZ0MNRW4jeOTmBFCHPBa0v32/3MqCtKsB9wKWYirLwEx97K90Q1DdhBT8lsr+NI4T/+6zN3rGOeQdmzIFkVHiYcREDsex4IpDKbHONF2ts+zGEqltLuMgzVlVJcT+DRCCw0WEaPWE7Cjw/qfH0Df3KXWddh8kwPgsKe7Z7tqukZmiqrSy4+vxiayK+XXkbg==</ds:SignatureValue>
+                <ds:KeyInfo Id="KI-dafaac5a-0126-4a60-8183-4436b3eb6616">
+                    <wsse:SecurityTokenReference wsu:Id="STR-b6d23249-861a-4453-b066-5bba4161e3f8">
+                        <wsse:Reference URI="#X509-7cc8378a-6fbc-49e7-ab24-6da45f2173e2" ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3"/>
+                    </wsse:SecurityTokenReference>
+                </ds:KeyInfo>
+            </ds:Signature>
+        </wsse:Security>
+        <eb:Messaging env:mustUnderstand="true" wsu:Id="id-e5f1258b-4535-481b-a8f4-c5170960a5d1" xmlns:eb="http://docs.oasis-open.org/ebxml-msg/ebms/v3.0/ns/core/200704/" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
+            <ns6:UserMessage mpc="urn:normal" xmlns:ns10="http://uri.etsi.org/2918/v1.2.1#" xmlns:ns11="http://uri.etsi.org/01903/v1.3.2#" xmlns:ns2="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns3="http://www.unece.org/cefact/namespaces/StandardBusinessDocumentHeader" xmlns:ns4="http://www.w3.org/2003/05/soap-envelope" xmlns:ns5="http://www.w3.org/2000/09/xmldsig#" xmlns:ns6="http://docs.oasis-open.org/ebxml-msg/ebms/v3.0/ns/core/200704/" xmlns:ns7="http://docs.oasis-open.org/ebxml-bp/ebbp-signals-2.0" xmlns:ns8="http://www.w3.org/1999/xlink" xmlns:ns9="http://begrep.difi.no/sdp/schema_v10">
+                <ns6:MessageInfo>
+                    <ns6:Timestamp>2019-04-15T22:07:50.739+02:00</ns6:Timestamp>
+                    <ns6:MessageId>fe3f28f5-5b64-40ae-8d46-1faff6606ccc</ns6:MessageId>
+                </ns6:MessageInfo>
+                <ns6:PartyInfo>
+                    <ns6:From>
+                        <ns6:PartyId type="urn:oasis:names:tc:ebcore:partyid-type:iso6523:9908">9908:123456789</ns6:PartyId>
+                        <ns6:Role>urn:sdp:meldingsformidler</ns6:Role>
+                    </ns6:From>
+                    <ns6:To>
+                        <ns6:PartyId type="urn:oasis:names:tc:ebcore:partyid-type:iso6523:9908">9908:984661185</ns6:PartyId>
+                        <ns6:Role>urn:sdp:postkasseleverandør</ns6:Role>
+                    </ns6:To>
+                </ns6:PartyInfo>
+                <ns6:CollaborationInfo>
+                    <ns6:AgreementRef>http://begrep.difi.no/SikkerDigitalPost/1.0/transportlag/Meldingsutveksling/FormidleDigitalPostForsendelse</ns6:AgreementRef>
+                    <ns6:Service>SDP</ns6:Service>
+                    <ns6:Action>FormidleDigitalPost</ns6:Action>
+                    <ns6:ConversationId>b8e8a64b-4d7d-43af-89b2-39b74dbb2550</ns6:ConversationId>
+                </ns6:CollaborationInfo>
+                <ns6:PayloadInfo>
+                    <ns6:PartInfo/>
+                    <ns6:PartInfo href="cid:0e1c44cf-5e09-4e9e-a8e5-7315d515b62e@meldingsformidler.sdp.difi.no">
+                        <ns6:PartProperties>
+                            <ns6:Property name="MimeType">application/cms</ns6:Property>
+                            <ns6:Property name="Content">sdp:Dokumentpakke</ns6:Property>
+                        </ns6:PartProperties>
+                    </ns6:PartInfo>
+                </ns6:PayloadInfo>
+            </ns6:UserMessage>
+        </eb:Messaging>
+    </env:Header>
+    <env:Body wsu:Id="soapBody" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
+        <ns3:StandardBusinessDocument xmlns:ns3="http://www.unece.org/cefact/namespaces/StandardBusinessDocumentHeader" xmlns:ns5="http://www.w3.org/2000/09/xmldsig#" xmlns:ns9="http://begrep.difi.no/sdp/schema_v10">
+            <ns3:StandardBusinessDocumentHeader>
+                <ns3:HeaderVersion>1.0</ns3:HeaderVersion>
+                <ns3:Sender>
+                    <ns3:Identifier Authority="urn:oasis:names:tc:ebcore:partyid-type:iso6523:9908">9908:889640782</ns3:Identifier>
+                </ns3:Sender>
+                <ns3:Receiver>
+                    <ns3:Identifier Authority="urn:oasis:names:tc:ebcore:partyid-type:iso6523:9908">9908:984661185</ns3:Identifier>
+                </ns3:Receiver>
+                <ns3:DocumentIdentification>
+                    <ns3:Standard>urn:no:difi:sdp:1.0</ns3:Standard>
+                    <ns3:TypeVersion>1.0</ns3:TypeVersion>
+                    <ns3:InstanceIdentifier>b8e8a64b-4d7d-43af-89b2-39b74dbb2550</ns3:InstanceIdentifier>
+                    <ns3:Type>digitalPost</ns3:Type>
+                    <ns3:CreationDateAndTime>2019-04-15T22:07:48.617+02:00</ns3:CreationDateAndTime>
+                </ns3:DocumentIdentification>
+                <ns3:BusinessScope>
+                    <ns3:Scope>
+                        <ns3:Type>ConversationId</ns3:Type>
+                        <ns3:InstanceIdentifier>171bf87b-575f-4f20-a43f-f982230f6d8c</ns3:InstanceIdentifier>
+                        <ns3:Identifier>urn:no:difi:sdp:1.0</ns3:Identifier>
+                    </ns3:Scope>
+                </ns3:BusinessScope>
+            </ns3:StandardBusinessDocumentHeader>
+            <ns9:digitalPost>
+                <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+                    <SignedInfo>
+                        <CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+                        <SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+                        <Reference URI="">
+                            <Transforms>
+                                <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+                            </Transforms>
+                            <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+                            <DigestValue>RM1u2EnvyykKA79qiV+ipGzfHMz96N/Rq1rFuiNMuUk=</DigestValue>
+                        </Reference>
+                    </SignedInfo>
+                    <SignatureValue>hfx/l6QO1RD4k6E6QDNzGV+vZGYLF+HCU5JLPNGCfZMZWnjFEjepb/Ow7WrdIfopsGBCycV+q5BR
+vmLAija6Yr9WWdSPzuqVfsDbWtUE8a9TG6cqoLCZDejmtPcL7PsuxCNIzSjCwEu6n3u1yLDCJ6oo
+4BuxZYtgZJgx7QweE/5j0ww8AzD1cKRF15ODvYHGNF837HWzwOiRXnT9kLxfKmy7dgL4yorfGiJR
+IoqsU3mRHGdFz98layYyVUdsZXQk+I0qEJt2Fk45kNVs/fqJGhgtSjKyoOZy/xpCPurf/ZU7HiNY
+Bxo29VqVgxfuMNYCShu7ZVttYc4SZnN5Aeoqfg==</SignatureValue>
+                    <KeyInfo>
+                        <X509Data>
+                            <X509Certificate>MIIC+zCCAeOgAwIBAgIEQ0kbRDANBgkqhkiG9w0BAQsFADAnMSUwIwYDVQQDDBxEaWdpcG9zdCBU
+ZXN0IENlcnQgQXV0aG9yaXR5MB4XDTE5MDQxNDIwMDc0OFoXDTE5MTAxNTIwMDc0OFowFDESMBAG
+A1UEAwwJODg5NjQwNzgyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuIi4ppAIqQaE
+vclq/7gCxm+/8Yfmd8oO2nPWryWeUM5wPOcVWbeR6fRn0ng6a9e/zF05fejqKf0sfoWrgz2+eh5a
+favII1wKGKNOf5qg+R2HPucZ9XnV7PkAXmTABDNC7VHxVKzSCbgISL4J/CCr6jOfsAi70KSuuUyo
+VXHSEsjm98aY7sPpLDutqg7BDtcKWkDw6S3636NJ9pOeosgroZwDZYDEX0nWcOPgEx6Z4x1xUoIF
+ttJx2eqsXQYOQVcdRjvi1yYP/D4otAHsUYu/kidNEmOKJ1HECwBITg+8JIrj49hhHbZPMtTJ+DCO
+Yx4vsRY/SJMMZcs+TeLsIA/DqQIDAQABo0IwQDAdBgNVHQ4EFgQU6HRnKbUeHbZgZtWInfcwklJ/
+RXkwHwYDVR0jBBgwFoAUKYKJg/t4gJpxzSp0SAfVQ5q6cvMwDQYJKoZIhvcNAQELBQADggEBACP0
+q8cOaFw69AB/+R7rVbfzzMIomVe/33hpNLP4kBfzA2Kz25tbz5LF9/GMhD+Gz2Byp+5HzvE4E6tP
++PZtjmdEEnpra8NO/A0i/eShe4ULUvMB3kYj2Ynu6VoEdtPrJjfh0zrCXkXii+lFBAZ2V9OFa2Xo
+JHuY76/nz33Kn5gX5bmif4ku1GPLBAnWy7un9SVkO+Oxik2hoADTo1nC99aSnimR5ClHZzLiFA+F
+GzVJwE6F4bW6usOXdvL/DjSO98tIpRZE8/gyQ5G5Inw6/3gO6ZVGSD31zki+8ytDQtqUN1mT72Tt
+p+8EcvFWaQDq9SNyUqVZ9a0/xbtqJj0apG0=</X509Certificate>
+                        </X509Data>
+                    </KeyInfo>
+                </Signature>
+                <ns9:avsender>
+                    <ns9:organisasjon>9908:889640782</ns9:organisasjon>
+                </ns9:avsender>
+                <ns9:mottaker>
+                    <ns9:person>
+                        <ns9:personidentifikator>01013300001</ns9:personidentifikator>
+                        <ns9:postkasseadresse>ola.nordmann#0ABC</ns9:postkasseadresse>
+                    </ns9:person>
+                </ns9:mottaker>
+                <ns9:digitalPostInfo>
+                    <ns9:aapningskvittering>false</ns9:aapningskvittering>
+                    <ns9:sikkerhetsnivaa>3</ns9:sikkerhetsnivaa>
+                    <ns9:ikkeSensitivTittel lang="no">Ikke-sensistiv dokument subject</ns9:ikkeSensitivTittel>
+                </ns9:digitalPostInfo>
+                <ns9:dokumentpakkefingeravtrykk>
+                    <ns5:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+                    <ns5:DigestValue>bB3MSFw53APknzuIr5UgVolnffEcaCKWWh8aJdOBB4M=</ns5:DigestValue>
+                </ns9:dokumentpakkefingeravtrykk>
+            </ns9:digitalPost>
+        </ns3:StandardBusinessDocument>
+    </env:Body>
+</env:Envelope>

--- a/pom.xml
+++ b/pom.xml
@@ -25,11 +25,9 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-        <config.profiler>inmemhsql</config.profiler>
         <org.slf4j.version>1.7.26</org.slf4j.version>
         <spring.ws.version>3.0.7.RELEASE</spring.ws.version>
         <wss4j.version>2.2.2</wss4j.version>
-        <hamcrest.version>2.1</hamcrest.version>
         <jaxb2-basics.version>0.12.0</jaxb2-basics.version>
     </properties>
 
@@ -44,19 +42,7 @@
             <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest</artifactId>
-                <version>${hamcrest.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-core</artifactId>
-                <version>${hamcrest.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-library</artifactId>
-                <version>${hamcrest.version}</version>
+                <version>2.1</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -64,6 +50,12 @@
                 <artifactId>java-8-matchers</artifactId>
                 <scope>test</scope>
                 <version>1.6</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.hamcrest</groupId>
+                        <artifactId>hamcrest-core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
@@ -100,6 +92,12 @@
                 <artifactId>junit</artifactId>
                 <version>4.12</version>
                 <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.hamcrest</groupId>
+                        <artifactId>hamcrest-core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
@@ -321,7 +319,7 @@
                 <plugin>
                     <groupId>com.github.siom79.japicmp</groupId>
                     <artifactId>japicmp-maven-plugin</artifactId>
-                    <version>0.13.1</version>
+                    <version>0.14.0</version>
                     <configuration>
                         <newVersion>
                             <file><path>${project.build.directory}/${project.build.finalName}.${project.packaging}</path></file>
@@ -356,6 +354,8 @@
                                 <excludes>
                                     <exclude>*:*:*:*:compile</exclude>
                                     <exclude>*:*:*:*:runtime</exclude>
+                                    <exclude>org.hamcrest:hamcrest-library</exclude>
+                                    <exclude>org.hamcrest:hamcrest-core</exclude>
                                 </excludes>
                                 <includes>
                                     <include>no.digipost:sdp-api-commons</include>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
         <org.slf4j.version>1.7.26</org.slf4j.version>
         <spring.ws.version>3.0.7.RELEASE</spring.ws.version>
-        <wss4j.version>2.2.2</wss4j.version>
+        <wss4j.version>2.2.3</wss4j.version>
         <jaxb2-basics.version>0.12.0</jaxb2-basics.version>
     </properties>
 
@@ -102,13 +102,13 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>2.25.0</version>
+                <version>2.27.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>nl.jqno.equalsverifier</groupId>
                 <artifactId>equalsverifier</artifactId>
-                <version>3.1.7</version>
+                <version>3.1.8</version>
                 <scope>test</scope>
             </dependency>
 
@@ -229,7 +229,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.5.7</version>
+                <version>4.5.8</version>
                 <exclusions>
                     <exclusion>
                         <groupId>commons-logging</groupId>
@@ -246,7 +246,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.8.1</version>
+                <version>3.9</version>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -261,18 +261,6 @@
             </dependency>
 
             <dependency>
-                <groupId>com.sun.mail</groupId>
-                <artifactId>javax.mail</artifactId>
-                <version>1.6.2</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>javax.activation</groupId>
-                        <artifactId>activation</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <dependency>
                 <groupId>jakarta.xml.soap</groupId>
                 <artifactId>jakarta.xml.soap-api</artifactId>
                 <version>1.4.1</version>
@@ -418,7 +406,6 @@
                                     <include>no.digipost:sdp-xsd</include>
                                     <include>aopalliance:aopalliance</include>
                                     <include>com.sun.xml.wsit:wsit-rt</include>
-                                    <include>com.sun.mail:javax.mail</include>
                                     <include>commons-codec:commons-codec</include>
                                     <include>jaxen:jaxen</include>
                                     <include>joda-time:joda-time</include>

--- a/pom.xml
+++ b/pom.xml
@@ -27,9 +27,7 @@
 
         <config.profiler>inmemhsql</config.profiler>
         <org.slf4j.version>1.7.26</org.slf4j.version>
-        <spring.version>5.1.5.RELEASE</spring.version>
         <spring.ws.version>3.0.7.RELEASE</spring.ws.version>
-        <spring.security.version>5.1.4.RELEASE</spring.security.version>
         <wss4j.version>2.2.2</wss4j.version>
         <hamcrest.version>2.1</hamcrest.version>
         <jaxb2-basics.version>0.12.0</jaxb2-basics.version>
@@ -125,23 +123,18 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-framework-bom</artifactId>
-                <version>${spring.version}</version>
+                <version>5.1.6.RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
 
             <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-core</artifactId>
-                <version>${spring.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>commons-logging</groupId>
-                        <artifactId>commons-logging</artifactId>
-                    </exclusion>
-                </exclusions>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-bom</artifactId>
+                <version>5.1.5.RELEASE</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
-
 
             <!-- Spring WS -->
             <dependency>
@@ -149,14 +142,6 @@
                 <artifactId>spring-ws-core</artifactId>
                 <version>${spring.ws.version}</version>
                 <exclusions>
-                    <exclusion>
-                        <groupId>commons-logging</groupId>
-                        <artifactId>commons-logging</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>javax.xml.stream</groupId>
-                        <artifactId>stax-api</artifactId>
-                    </exclusion>
                     <exclusion>
                         <groupId>commons-io</groupId>
                         <artifactId>commons-io</artifactId>
@@ -169,18 +154,6 @@
                 <version>${spring.ws.version}</version>
                 <exclusions>
                     <exclusion>
-                        <groupId>commons-logging</groupId>
-                        <artifactId>commons-logging</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.sun.xml.wsit</groupId>
-                        <artifactId>xws-security</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.ws.security</groupId>
-                        <artifactId>wss4j</artifactId>
-                    </exclusion>
-                    <exclusion>
                         <groupId>net.sf.ehcache</groupId>
                         <artifactId>ehcache</artifactId>
                     </exclusion>
@@ -191,19 +164,10 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>org.springframework.security</groupId>
-                <artifactId>spring-security-core</artifactId>
-                <version>${spring.security.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.springframework.ws</groupId>
                 <artifactId>spring-xml</artifactId>
                 <version>${spring.ws.version}</version>
                 <exclusions>
-                    <exclusion>
-                        <groupId>commons-logging</groupId>
-                        <artifactId>commons-logging</artifactId>
-                    </exclusion>
                     <exclusion>
                         <groupId>commons-io</groupId>
                         <artifactId>commons-io</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -181,10 +181,6 @@
                 <version>${wss4j.version}</version>
                 <exclusions>
                     <exclusion>
-                        <groupId>commons-logging</groupId>
-                        <artifactId>commons-logging</artifactId>
-                    </exclusion>
-                    <exclusion>
                         <groupId>net.sf.ehcache</groupId>
                         <artifactId>ehcache</artifactId>
                     </exclusion>
@@ -196,20 +192,8 @@
                 <version>${wss4j.version}</version>
                 <exclusions>
                     <exclusion>
-                        <groupId>commons-logging</groupId>
-                        <artifactId>commons-logging</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>javax.xml.stream</groupId>
-                        <artifactId>stax-api</artifactId>
-                    </exclusion>
-                    <exclusion>
                         <groupId>io.dropwizard.metrics</groupId>
                         <artifactId>metrics-core</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.fasterxml.woodstox</groupId>
-                        <artifactId>woodstox-core</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>org.apache.geronimo.javamail</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>co.unruly</groupId>
+                <artifactId>java-8-matchers</artifactId>
+                <scope>test</scope>
+                <version>1.6</version>
+            </dependency>
+            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${org.slf4j.version}</version>
@@ -293,12 +299,6 @@
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpcore</artifactId>
                 <version>4.4.11</version>
-            </dependency>
-
-            <dependency>
-                <groupId>jaxen</groupId>
-                <artifactId>jaxen</artifactId>
-                <version>1.1.6</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -192,8 +192,16 @@
                 <version>${wss4j.version}</version>
                 <exclusions>
                     <exclusion>
-                        <groupId>io.dropwizard.metrics</groupId>
-                        <artifactId>metrics-core</artifactId>
+                        <groupId>org.opensaml</groupId>
+                        <artifactId>opensaml-saml-impl</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.opensaml</groupId>
+                        <artifactId>opensaml-xacml-impl</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.opensaml</groupId>
+                        <artifactId>opensaml-xacml-saml-impl</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>org.apache.geronimo.javamail</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>sdp-shared</artifactId>
-    <version>2.9-SNAPSHOT</version>
+    <version>2.9</version>
     <packaging>pom</packaging>
     <name>SDP Shared</name>
     <description>Delt kode for Sikker Digital Post</description>
@@ -34,7 +34,7 @@
     <scm>
         <connection>scm:git:git@github.com:digipost/sdp-shared.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/sdp-shared.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>2.9</tag>
     </scm>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -355,6 +355,10 @@
                     <artifactId>maven-notice-plugin</artifactId>
                     <version>1.1.0</version>
                     <configuration>
+                        <includeScopes>
+                            <scope>compile</scope>
+                            <scope>runtime</scope>
+                        </includeScopes>
                         <noticeTemplate>${project.basedir}/src/main/notice/NOTICE.template</noticeTemplate>
                         <licenseMapping>
                             <param>${project.basedir}/src/main/notice/license-mappings.xml</param>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>sdp-shared</artifactId>
-    <version>2.9</version>
+    <version>2.10-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>SDP Shared</name>
     <description>Delt kode for Sikker Digital Post</description>
@@ -34,7 +34,7 @@
     <scm>
         <connection>scm:git:git@github.com:digipost/sdp-shared.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/sdp-shared.git</developerConnection>
-        <tag>2.9</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <dependencyManagement>

--- a/xsd/NOTICE
+++ b/xsd/NOTICE
@@ -8,10 +8,5 @@ Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.html
 
 This software includes third party software subject to the following licenses:
 
-  Hamcrest under BSD Licence 3
-  Hamcrest Core under BSD Licence 3
-  Hamcrest Library under BSD Licence 3
   JAXB2 Basics - Runtime under BSD-Style License
-  JUnit under Eclipse Public License 1.0
-  SDP Shared - XSD & JAXB under The Apache Software License, Version 2.0
 

--- a/xsd/pom.xml
+++ b/xsd/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>no.digipost</groupId>
 		<artifactId>sdp-shared</artifactId>
-		<version>2.9-SNAPSHOT</version>
+		<version>2.9</version>
 	</parent>
 
 

--- a/xsd/pom.xml
+++ b/xsd/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>no.digipost</groupId>
 		<artifactId>sdp-shared</artifactId>
-		<version>2.9</version>
+		<version>2.10-SNAPSHOT</version>
 	</parent>
 
 

--- a/xsd/pom.xml
+++ b/xsd/pom.xml
@@ -28,11 +28,6 @@
             <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <scope>test</scope>
-        </dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
- remove unused Spring-based XPath util: 696ee6e.
  Dette var ikke i bruk av hverken biblioteket selv, klientbibliotek, eller Meldingsformidler. 
- Bruker JAXP (JDK-basert) i stedet for Jaxen for XPath-evaluering for å hente ut referanser fra EBMS-melding. Slipper å dra inn et helt XML-library for en liten xpath-greie. be86646
- Fjerner OpenSAML, brukes ikke. 1482262
- Fjerner alt av JavaMail/Jakarta Mail. Vet ikke hva disse var dratt inn for i utgangspunktet. Tipper de har blitt med via noe annet en eller annen, også har vi selv dratt de inn på et punkt fordi vi har trodd at vi trenger de. bb49e84
- Oppdaterer Spring Security p.g.a. sårbarhet c3d1a7c
- Rydder litt i unødvendige exclusions i POM da240f9
