### PR TITLE
More insisting on EE4J Metro SAAJ RI as default implementation

### DIFF
--- a/api-client/pom.xml
+++ b/api-client/pom.xml
@@ -40,12 +40,10 @@
             <artifactId>jakarta.xml.soap-api</artifactId>
         </dependency>
 
-        <!-- SAAJ RI -->
-        <!-- Including this in order to prevent concurrency issue on JDK 7 -->
+        <!-- SAAJ RI https://javaee.github.io/metro-saaj/ -->
         <dependency>
             <groupId>com.sun.xml.messaging.saaj</groupId>
             <artifactId>saaj-impl</artifactId>
-            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/api-client/pom.xml
+++ b/api-client/pom.xml
@@ -28,10 +28,6 @@
             <groupId>org.springframework.ws</groupId>
             <artifactId>spring-ws-core</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-core</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>jakarta.activation</groupId>

--- a/api-client/pom.xml
+++ b/api-client/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>no.digipost</groupId>
         <artifactId>sdp-shared</artifactId>
-        <version>2.12</version>
+        <version>2.13-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/api-client/pom.xml
+++ b/api-client/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>no.digipost</groupId>
         <artifactId>sdp-shared</artifactId>
-        <version>2.12-SNAPSHOT</version>
+        <version>2.12</version>
     </parent>
 
     <dependencies>

--- a/api-client/src/main/java/no/digipost/api/MessageFactorySupplier.java
+++ b/api-client/src/main/java/no/digipost/api/MessageFactorySupplier.java
@@ -1,0 +1,43 @@
+package no.digipost.api;
+
+import javax.xml.soap.MessageFactory;
+import javax.xml.soap.SOAPConstants;
+import javax.xml.soap.SOAPException;
+
+
+@FunctionalInterface
+public interface MessageFactorySupplier {
+
+    /**
+     * This resolves the {@link com.sun.xml.messaging.saaj.soap.ver1_2.SOAPMessageFactory1_2Impl} from the
+     * <a href="https://javaee.github.io/metro-saaj/">Eclipse Enterprise for Java (EE4J) Metro SAAJ RI</a>.
+     * <p>
+     * This is the default SAAJ implementation used by this library, and is preferred because the implementation
+     * bundled in the JDK has certain concurrency issues.
+     */
+    MessageFactorySupplier METRO_SAAJ_RI = com.sun.xml.messaging.saaj.soap.ver1_2.SOAPMessageFactory1_2Impl::new;
+
+    /**
+     * This resolves which MessageFactory implementation to use using standard JDK mechanism by
+     * invoking {@link MessageFactory#newInstance(String)} with {@link SOAPConstants#SOAP_1_2_PROTOCOL} as
+     * argument. This may be apropriate if you use an application server runtime environment, and you want
+     * to use the SAAJ implementation supplied by it.
+     *
+     * <h2>Note</h2>
+     * The SAAJ implementation bundled with the JDK has certain performance and concurrency issues:
+     * <ul>
+     *  <li><a href="https://github.com/eclipse-ee4j/metro-saaj/issues/73">Issue #73: Make EnvelopeFactory ParserPool capacity configurable</a></li>
+     *  <li><a href="https://github.com/eclipse-ee4j/metro-saaj/pull/117">Pull-request #117: Fix stability and security problem</a></li>
+     * </ul>
+     * You should not use this MessageFactoryResolver unless you have a good reason to, either if
+     * you have configured your runtime environment to create a certain SAAJ implementation specified
+     * by the {@code javax.xml.soap.MessageFactory} system property, or this is preconfigured
+     * by your runtime environment, e.g. an application server.
+     */
+    MessageFactorySupplier JDK_FACTORY = () -> MessageFactory.newInstance(SOAPConstants.SOAP_1_2_PROTOCOL);
+
+
+
+    MessageFactory createMessageFactory() throws SOAPException;
+
+}

--- a/api-client/src/main/java/no/digipost/api/interceptors/steps/ReferenceValidatorStep.java
+++ b/api-client/src/main/java/no/digipost/api/interceptors/steps/ReferenceValidatorStep.java
@@ -6,13 +6,14 @@ import org.oasis_open.docs.ebxml_bp.ebbp_signals_2.MessagePartNRInformation;
 import org.oasis_open.docs.ebxml_bp.ebbp_signals_2.NonRepudiationInformation;
 import org.oasis_open.docs.ebxml_msg.ebms.v3_0.ns.core._200704.Messaging;
 import org.springframework.oxm.jaxb.Jaxb2Marshaller;
-import org.springframework.security.crypto.codec.Base64;
 import org.springframework.ws.soap.SoapHeaderElement;
 import org.springframework.ws.soap.SoapMessage;
 import org.w3.xmldsig.Reference;
 import org.w3.xmldsig.Transform;
 
 import java.util.Arrays;
+import java.util.Base64;
+import java.util.Base64.Encoder;
 import java.util.Collection;
 
 public class ReferenceValidatorStep implements EbmsProcessingStep {
@@ -50,7 +51,8 @@ public class ReferenceValidatorStep implements EbmsProcessingStep {
             throw new RuntimeException("Unexpected digest method. Expected:" + expected.getDigestMethod().getAlgorithm() + " Actual:" + actual.getDigestMethod().getAlgorithm());
         }
         if (!Arrays.equals(expected.getDigestValue(), actual.getDigestValue())) {
-            throw new RuntimeException("Unexpected digest value. Expected:" + Base64.encode(expected.getDigestValue()) + " Actual:" + Base64.encode(actual.getDigestValue()));
+            Encoder base64Encoder = Base64.getEncoder();
+            throw new RuntimeException("Unexpected digest value. Expected:" + base64Encoder.encode(expected.getDigestValue()) + " Actual:" + base64Encoder.encode(actual.getDigestValue()));
         }
         validateTransforms(expected, actual);
     }

--- a/api-commons/pom.xml
+++ b/api-commons/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>no.digipost</groupId>
         <artifactId>sdp-shared</artifactId>
-        <version>2.12</version>
+        <version>2.13-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/api-commons/pom.xml
+++ b/api-commons/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>no.digipost</groupId>
         <artifactId>sdp-shared</artifactId>
-        <version>2.12-SNAPSHOT</version>
+        <version>2.12</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>sdp-shared</artifactId>
-    <version>2.12-SNAPSHOT</version>
+    <version>2.12</version>
     <packaging>pom</packaging>
     <name>SDP Shared</name>
     <description>Delt kode for Sikker Digital Post</description>
@@ -34,7 +34,7 @@
     <scm>
         <connection>scm:git:git@github.com:digipost/sdp-shared.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/sdp-shared.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>2.12</tag>
     </scm>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>sdp-shared</artifactId>
-    <version>2.12</version>
+    <version>2.13-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>SDP Shared</name>
     <description>Delt kode for Sikker Digital Post</description>
@@ -34,7 +34,7 @@
     <scm>
         <connection>scm:git:git@github.com:digipost/sdp-shared.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/sdp-shared.git</developerConnection>
-        <tag>2.12</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>no.digipost</groupId>
         <artifactId>digipost-open-super-pom</artifactId>
-        <version>2</version>
+        <version>3</version>
         <relativePath />
     </parent>
 
@@ -108,7 +108,7 @@
             <dependency>
                 <groupId>nl.jqno.equalsverifier</groupId>
                 <artifactId>equalsverifier</artifactId>
-                <version>3.1.8</version>
+                <version>3.1.9</version>
                 <scope>test</scope>
             </dependency>
 
@@ -270,7 +270,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.0</version>
+                    <version>3.8.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
@@ -278,7 +278,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.1.2</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>
@@ -319,7 +319,7 @@
                 <plugin>
                     <groupId>com.github.siom79.japicmp</groupId>
                     <artifactId>japicmp-maven-plugin</artifactId>
-                    <version>0.14.0</version>
+                    <version>0.14.1</version>
                     <configuration>
                         <newVersion>
                             <file><path>${project.build.directory}/${project.build.finalName}.${project.packaging}</path></file>

--- a/xsd/pom.xml
+++ b/xsd/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>no.digipost</groupId>
 		<artifactId>sdp-shared</artifactId>
-		<version>2.12</version>
+		<version>2.13-SNAPSHOT</version>
 	</parent>
 
 

--- a/xsd/pom.xml
+++ b/xsd/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>no.digipost</groupId>
 		<artifactId>sdp-shared</artifactId>
-		<version>2.12-SNAPSHOT</version>
+		<version>2.12</version>
 	</parent>
 
 


### PR DESCRIPTION
We have been notified of cases where the runtime uses the JDK-bundled SAAJ even though saaj-impl-1.5.1.jar is on classpath. This is problematic because of performance and concurrency issues existing in the implementation offered by the JDK.

The `MessageSender.Builder` now uses the constructor for `com.sun.xml.messaging.saaj.soap.ver1_2.SOAPMessageFactory1_2Impl()` by default instead of relying on the discovery mechanism of `MessageFactory.newInstance`. This is because we need to force the use of the SAAJ RI to avoid performance and concurrency issues with the implementation offered by the JDK. It is however possible to override this to use the JDK factory, if preferred.

