### PR TITLE
Properly defer instantiating SAAJ MessageFactory

### DIFF
--- a/api-client/pom.xml
+++ b/api-client/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>no.digipost</groupId>
         <artifactId>sdp-shared</artifactId>
-        <version>2.13-SNAPSHOT</version>
+        <version>2.13</version>
     </parent>
 
     <dependencies>

--- a/api-client/pom.xml
+++ b/api-client/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>no.digipost</groupId>
         <artifactId>sdp-shared</artifactId>
-        <version>2.13</version>
+        <version>2.14-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/api-client/src/main/java/no/digipost/api/MessageFactorySupplier.java
+++ b/api-client/src/main/java/no/digipost/api/MessageFactorySupplier.java
@@ -15,7 +15,9 @@ public interface MessageFactorySupplier {
      * This is the default SAAJ implementation used by this library, and is preferred because the implementation
      * bundled in the JDK has certain concurrency issues.
      */
-    MessageFactorySupplier METRO_SAAJ_RI = com.sun.xml.messaging.saaj.soap.ver1_2.SOAPMessageFactory1_2Impl::new;
+    static MessageFactorySupplier metroSaajRI() {
+        return com.sun.xml.messaging.saaj.soap.ver1_2.SOAPMessageFactory1_2Impl::new;
+    }
 
     /**
      * This resolves which MessageFactory implementation to use using standard JDK mechanism by
@@ -34,7 +36,21 @@ public interface MessageFactorySupplier {
      * by the {@code javax.xml.soap.MessageFactory} system property, or this is preconfigured
      * by your runtime environment, e.g. an application server.
      */
-    MessageFactorySupplier JDK_FACTORY = () -> MessageFactory.newInstance(SOAPConstants.SOAP_1_2_PROTOCOL);
+    static MessageFactorySupplier jdkFactory() {
+        return () -> MessageFactory.newInstance(SOAPConstants.SOAP_1_2_PROTOCOL);
+    }
+
+    /**
+     * Get the default {@code MessageFactorySupplier} (i.e. {@link #metroSaajRI()})
+     * if given {@code null} as argument.
+     *
+     * @param messageFactory the factory to check if it is {@code null}.
+     * @return the given {@code messageFactory} or if it is {@code null}, the result
+     *         from {@link #metroSaajRI()}.
+     */
+    static MessageFactorySupplier defaultIfNull(MessageFactorySupplier messageFactory) {
+        return messageFactory != null ? messageFactory : metroSaajRI();
+    }
 
 
 

--- a/api-client/src/main/java/no/digipost/api/MessageSender.java
+++ b/api-client/src/main/java/no/digipost/api/MessageSender.java
@@ -117,7 +117,7 @@ public interface MessageSender {
         private Duration validateAfterInactivity = Duration.of(2, ChronoUnit.SECONDS);
         private SoapLog.LogLevel logLevel = LogLevel.NONE;
         private ClientInterceptorWrapper clientInterceptorWrapper = interceptor -> interceptor;
-        private MessageFactorySupplier messageFactorySupplier = MessageFactorySupplier.METRO_SAAJ_RI;
+        private MessageFactorySupplier messageFactorySupplier;
 
 
         private Builder(EbmsEndpointUriBuilder uri, EbmsAktoer databehandler, EbmsAktoer tekniskMottaker,
@@ -257,7 +257,7 @@ public interface MessageSender {
 
             SaajSoapMessageFactory factory;
             try {
-                MessageFactory messageFactory = messageFactorySupplier.createMessageFactory();
+                MessageFactory messageFactory = MessageFactorySupplier.defaultIfNull(messageFactorySupplier).createMessageFactory();
                 LOG.info("Using instance of {} as {}", messageFactory.getClass().getName(), MessageFactory.class.getSimpleName());
                 factory = new SaajSoapMessageFactory(messageFactory);
                 factory.setSoapVersion(SoapVersion.SOAP_12);

--- a/api-commons/pom.xml
+++ b/api-commons/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>no.digipost</groupId>
         <artifactId>sdp-shared</artifactId>
-        <version>2.13-SNAPSHOT</version>
+        <version>2.13</version>
     </parent>
 
     <dependencies>

--- a/api-commons/pom.xml
+++ b/api-commons/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>no.digipost</groupId>
         <artifactId>sdp-shared</artifactId>
-        <version>2.13</version>
+        <version>2.14-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>sdp-shared</artifactId>
-    <version>2.13-SNAPSHOT</version>
+    <version>2.13</version>
     <packaging>pom</packaging>
     <name>SDP Shared</name>
     <description>Delt kode for Sikker Digital Post</description>
@@ -34,7 +34,7 @@
     <scm>
         <connection>scm:git:git@github.com:digipost/sdp-shared.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/sdp-shared.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>2.13</tag>
     </scm>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>sdp-shared</artifactId>
-    <version>2.13</version>
+    <version>2.14-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>SDP Shared</name>
     <description>Delt kode for Sikker Digital Post</description>
@@ -34,7 +34,7 @@
     <scm>
         <connection>scm:git:git@github.com:digipost/sdp-shared.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/sdp-shared.git</developerConnection>
-        <tag>2.13</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <dependencyManagement>

--- a/xsd/pom.xml
+++ b/xsd/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>no.digipost</groupId>
 		<artifactId>sdp-shared</artifactId>
-		<version>2.13-SNAPSHOT</version>
+		<version>2.13</version>
 	</parent>
 
 

--- a/xsd/pom.xml
+++ b/xsd/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>no.digipost</groupId>
 		<artifactId>sdp-shared</artifactId>
-		<version>2.13</version>
+		<version>2.14-SNAPSHOT</version>
 	</parent>
 
 


### PR DESCRIPTION
It should be possible to exclude `com.sun.xml.messaging.saaj:saaj-impl` from the classpath if one
chooses to use another SAAJ implementation. This changes so no code path
requires initializing Metro SAAJ-RI classes if the
`MessageSender.Builder` is instructed to use another SAAJ implementation.

This is a fix for the feature introduced in #107 (version 2.12), and it breaks the API backwards compatibility, but the release has promptly been marked as invalid, and has not been put to use yet, so we let this slide 😇 