### PR TITLE
Støtte for SEID2 i OrgnummerExtractor

### DIFF
--- a/api-commons/src/main/java/no/digipost/api/security/OrgnummerExtractor.java
+++ b/api-commons/src/main/java/no/digipost/api/security/OrgnummerExtractor.java
@@ -1,6 +1,8 @@
 package no.digipost.api.security;
 
 import no.digipost.api.representations.Organisasjonsnummer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
@@ -8,31 +10,44 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
+import static javax.security.auth.x500.X500Principal.RFC1779;
 
 public class OrgnummerExtractor {
 
-    private static final Pattern CN_PATTERN = Pattern.compile("CN=([0-9]{9})([^0-9].*)?$");
-    private static final Pattern BUYPASS_PATTERN = Pattern.compile("SERIALNUMBER=([0-9]{9})", CASE_INSENSITIVE);
-    public static final Collection<Pattern> PATTERNS = Arrays.asList(CN_PATTERN, BUYPASS_PATTERN, Pattern.compile(".*"));
+    private static final Logger LOG = LoggerFactory.getLogger(OrgnummerExtractor.class);
 
-    public Optional<Organisasjonsnummer> tryParse(final X509Certificate cert) {
-        String dn = cert.getSubjectDN().getName();
-        Matcher matcher = BUYPASS_PATTERN.matcher(dn);
-        if (matcher.find()) {
-            return Organisasjonsnummer.hvisGyldig(matcher.group(1));
-        }
-        matcher = CN_PATTERN.matcher(dn);
-        if (matcher.find()) {
-            return Organisasjonsnummer.hvisGyldig(matcher.group(1));
-        }
-        return Optional.empty();
+    private static final Pattern CN_PATTERN = Pattern.compile("CN=([0-9]{9})([^0-9].*)?$");
+
+    private static final Pattern BUYPASS_PATTERN = Pattern.compile("OID\\.2\\.5\\.4\\.5=([0-9]{9})", CASE_INSENSITIVE);
+
+    private static final Pattern SEID2_PATTERN = Pattern.compile("OID\\.2\\.5\\.4\\.97=(?:NTRNO-)?([0-9]{9})", CASE_INSENSITIVE);
+
+
+    public static final Collection<Pattern> PATTERNS = Arrays.asList(SEID2_PATTERN, CN_PATTERN, BUYPASS_PATTERN, Pattern.compile(".*"));
+
+    public Optional<Organisasjonsnummer> tryParse(X509Certificate cert) {
+        String dn = cert.getSubjectX500Principal().getName(RFC1779);
+        return Stream.of(SEID2_PATTERN, BUYPASS_PATTERN, CN_PATTERN)
+                .map(pattern -> tryFindOrgnr(dn, pattern))
+                .filter(Optional::isPresent).map(Optional::get)
+                .findFirst()
+                .flatMap(Organisasjonsnummer::hvisGyldig);
     }
 
-    public Organisasjonsnummer from(final X509Certificate cert) {
+    public Organisasjonsnummer from(X509Certificate cert) {
         return tryParse(cert).orElseThrow(() -> new IllegalArgumentException(
                 "Fant ikke organisasjonsnummer i [" + cert.getSubjectDN().getName() + "], " +
                         "issuer=[" + cert.getIssuerDN().getName() + "]"));
+    }
+
+    private static final Optional<String> tryFindOrgnr(CharSequence text, Pattern extractPattern) {
+        Optional<String> extracted = Optional.of(text).map(extractPattern::matcher).filter(Matcher::find).map(m -> m.group(1));
+        if (!extracted.isPresent() && LOG.isTraceEnabled()) {
+            LOG.trace("Orgnr ikke funnet i '{}' v.h.a. regex '{}'", text, extractPattern);
+        }
+        return extracted;
     }
 }


### PR DESCRIPTION
SEID2-støtte for å hente ut organisasjonsnummer fra virksomhetssertifikat.

Implementasjon tatt fra:
https://github.com/digipost/certificate-validator/blob/2.3-RC2/src/main/java/no/digipost/security/X509.java

Denne er egentlig nå kun i bruk i klientkode, og kunne således vært flyttet ut fra api-commons. Også litt usikker på hva i all verden som er poenget med `OrgnummerExtractor.PATTERNS`. Denne brukes til å sette constraints for certificate subjects i `Wss4jInterceptor` [(1)](https://github.com/digipost/sdp-shared/blob/main/api-commons/src/main/java/no/digipost/api/interceptors/Wss4jInterceptor.java#L307), [(2)](https://github.com/digipost/sdp-shared/blob/main/api-commons/src/main/java/no/digipost/api/interceptors/Wss4jInterceptor.java#L307) , men listen inkluderer et "allow all"-pattern, så det er ikke mye "constraints" å snakke om 🤷 