### PR TITLE
BouncyCastle 1.73 + convergence to javax-artifacts (replacing jakarta-equivalents)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,76 +1,59 @@
-name: Build and deploy
+name: Build and publish
+on: push
 
-on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8', '11.0.16+1' ]
-
-    name: build java ${{ matrix.java }}
-    steps:
-      - uses: actions/checkout@v1
-        with:
-          submodules: true
-      - name: Set up JDK
-        uses: actions/setup-java@v2.3.1
-        with:
-          distribution: zulu
-          java-version: ${{ matrix.java }}
-          server-id: github
-          cache: 'maven'
-      - name: Build with Maven
-        run: mvn -B package --no-transfer-progress --file pom.xml
-
-  makeversion:
-    if: github.ref != 'refs/heads/main'
-    needs: build
+        java: [ '8', '11' ]
+    name: Build on Java ${{ matrix.java }}
     runs-on: ubuntu-latest
-    name: Create version
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+          cache: "maven"
+      - name: Build with Maven
+        run: mvn -B clean verify --no-transfer-progress --show-version
+
+
+  publishing_parameters:
+    needs: build
+    name: Publishing parameters
+    runs-on: ubuntu-latest
     outputs:
+      is_release: ${{ steps.version.outputs.is_release }}
       version: ${{ steps.version.outputs.version }}
     steps:
-      - name: Decide on build version
+      - name: Determine version
         id: version
         run: |
           if [[ $GITHUB_REF == *"tags"* ]]; then
-            TAG=${GITHUB_REF#refs/tags/}
+            is_release=true
+            version=${GITHUB_REF#refs/tags/}
           else
-            TAG=${GITHUB_REF#refs/heads/}-SNAPSHOT
+            is_release=false
+            version=${GITHUB_REF#refs/heads/}-SNAPSHOT
           fi
-          echo ::set-output name=version::${TAG//\//-}
+          echo "is_release=${is_release//\//-}" >> $GITHUB_OUTPUT
+          echo "version=${version//\//-}" >> $GITHUB_OUTPUT
 
-  deploy_snapshot:
-    if: startsWith(github.ref, 'refs/heads/')
-    needs: makeversion
+
+  publish:
+    needs: publishing_parameters
+    name: Publish ${{ needs.publishing_parameters.outputs.version }}
     runs-on: ubuntu-latest
-
-    name: Deploy snapshot
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
         with:
-          submodules: true
-      - uses: digipost/action-maven-publish@1.1.0
+          submodules: recursive
+      - uses: digipost/action-maven-publish@v1
         with:
           sonatype_secrets: ${{ secrets.sonatype_secrets }}
-          release_version: ${{ needs.makeversion.outputs.version }}
-          perform_release: false
-
-  release:
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
-    needs: makeversion
-    name: Release to Sonatype
-    steps:
-      - name: Check out Git repository
-        uses: actions/checkout@v1
-        with:
-          submodules: true
-      - name: Release to Central Repository
-        uses: digipost/action-maven-publish@1.1.0
-        with:
-          sonatype_secrets: ${{ secrets.sonatype_secrets }}
-          release_version: ${{ needs.makeversion.outputs.version }}
-          perform_release: true
+          release_version: ${{ needs.publishing_parameters.outputs.version }}
+          perform_release: ${{ needs.publishing_parameters.outputs.is_release }}

--- a/api-client/NOTICE
+++ b/api-client/NOTICE
@@ -17,24 +17,24 @@ This software includes third party software subject to the following licenses:
   Apache XML Security for Java under Apache License, Version 2.0
   Bouncy Castle Provider under Bouncy Castle Licence
   Cryptacular Library under Apache 2 or GNU Lesser General Public License
+  Digipost JAXB Resolver - com.sun.xml.bind under The Apache Software License, Version 2.0
   Extended StAX API under Eclipse Distribution License - v 1.0
   Guava InternalFutureFailureAccess and InternalFutures under The Apache Software License, Version 2.0
   Guava: Google Core Libraries for Java under Apache License, Version 2.0
-  istack common utility code runtime under Eclipse Distribution License - v 1.0
-  Jakarta Activation under EDL 1.0
-  Jakarta Activation API jar under EDL 1.0
   Jakarta SOAP with Attachments API under Eclipse Distribution License - v 1.0
   Jakarta Web Services Metadata API under Eclipse Distribution License - v 1.0
-  Jakarta XML Binding API under Eclipse Distribution License - v 1.0
   Jakarta XML Web Services API under Eclipse Distribution License - v 1.0
   JASYPT: Java Simplified Encryption under The Apache Software License, Version 2.0
-  JAXB Runtime under Eclipse Distribution License - v 1.0
+  JavaBeans Activation Framework API jar under CDDL/GPLv2+CE
+  jaxb-api under CDDL 1.1 or GPL2 w/ CPE
   JAXB2 Basics - Runtime under BSD-Style License
   JCL 1.2 implemented over SLF4J under Apache License, Version 2.0
   Joda-Time under Apache License, Version 2.0
   JUL to SLF4J bridge under MIT License
   Log4j Implemented Over SLF4J under Apache Software Licenses
   MIME streaming extension under Eclipse Distribution License - v 1.0
+  Old JAXB Core under CDDL+GPL License
+  Old JAXB Runtime under Eclipse Distribution License - v 1.0
   saaj-impl under Eclipse Distribution License - v 1.0
   SDP Shared - API Commons under The Apache Software License, Version 2.0
   SDP Shared - XSD & JAXB under The Apache Software License, Version 2.0
@@ -54,5 +54,4 @@ This software includes third party software subject to the following licenses:
   spring-ws-core under Apache License, Version 2.0
   spring-ws-security under Apache License, Version 2.0
   spring-xml under Apache License, Version 2.0
-  TXW2 Runtime under Eclipse Distribution License - v 1.0
 

--- a/api-client/NOTICE
+++ b/api-client/NOTICE
@@ -21,11 +21,9 @@ This software includes third party software subject to the following licenses:
   Extended StAX API under Eclipse Distribution License - v 1.0
   Guava InternalFutureFailureAccess and InternalFutures under The Apache Software License, Version 2.0
   Guava: Google Core Libraries for Java under Apache License, Version 2.0
-  Jakarta SOAP with Attachments API under Eclipse Distribution License - v 1.0
-  Jakarta Web Services Metadata API under Eclipse Distribution License - v 1.0
-  Jakarta XML Web Services API under Eclipse Distribution License - v 1.0
   JASYPT: Java Simplified Encryption under The Apache Software License, Version 2.0
   JavaBeans Activation Framework API jar under CDDL/GPLv2+CE
+  javax.xml.soap API under CDDL + GPLv2 with classpath exception
   jaxb-api under CDDL 1.1 or GPL2 w/ CPE
   JAXB2 Basics - Runtime under BSD-Style License
   JCL 1.2 implemented over SLF4J under Apache License, Version 2.0

--- a/api-client/pom.xml
+++ b/api-client/pom.xml
@@ -36,8 +36,8 @@
 
         <!-- SAAJ API-->
         <dependency>
-            <groupId>jakarta.xml.soap</groupId>
-            <artifactId>jakarta.xml.soap-api</artifactId>
+            <groupId>javax.xml.soap</groupId>
+            <artifactId>javax.xml.soap-api</artifactId>
         </dependency>
 
         <!-- SAAJ RI https://javaee.github.io/metro-saaj/ -->

--- a/api-client/pom.xml
+++ b/api-client/pom.xml
@@ -14,10 +14,9 @@
     <dependencies>
 
         <dependency>
-            <groupId>jakarta.activation</groupId>
-            <artifactId>jakarta.activation-api</artifactId>
+            <groupId>javax.activation</groupId>
+            <artifactId>javax.activation-api</artifactId>
         </dependency>
-
         <dependency>
             <groupId>no.digipost</groupId>
             <artifactId>sdp-xsd</artifactId>

--- a/api-client/src/main/java/no/digipost/api/MessageFactorySupplier.java
+++ b/api-client/src/main/java/no/digipost/api/MessageFactorySupplier.java
@@ -25,7 +25,7 @@ public interface MessageFactorySupplier {
      * argument. This may be apropriate if you use an application server runtime environment, and you want
      * to use the SAAJ implementation supplied by it.
      *
-     * <h2>Note</h2>
+     * <p><strong>Note:</strong>
      * The SAAJ implementation bundled with the JDK has certain performance and concurrency issues:
      * <ul>
      *  <li><a href="https://github.com/eclipse-ee4j/metro-saaj/issues/73">Issue #73: Make EnvelopeFactory ParserPool capacity configurable</a></li>

--- a/api-commons/NOTICE
+++ b/api-commons/NOTICE
@@ -20,11 +20,9 @@ This software includes third party software subject to the following licenses:
   Extended StAX API under Eclipse Distribution License - v 1.0
   Guava InternalFutureFailureAccess and InternalFutures under The Apache Software License, Version 2.0
   Guava: Google Core Libraries for Java under Apache License, Version 2.0
-  Jakarta SOAP with Attachments API under Eclipse Distribution License - v 1.0
-  Jakarta Web Services Metadata API under Eclipse Distribution License - v 1.0
-  Jakarta XML Web Services API under Eclipse Distribution License - v 1.0
   JASYPT: Java Simplified Encryption under The Apache Software License, Version 2.0
   JavaBeans Activation Framework API jar under CDDL/GPLv2+CE
+  javax.xml.soap API under CDDL + GPLv2 with classpath exception
   jaxb-api under CDDL 1.1 or GPL2 w/ CPE
   JAXB2 Basics - Runtime under BSD-Style License
   JCL 1.2 implemented over SLF4J under Apache License, Version 2.0

--- a/api-commons/NOTICE
+++ b/api-commons/NOTICE
@@ -16,22 +16,22 @@ This software includes third party software subject to the following licenses:
   Apache XML Security for Java under Apache License, Version 2.0
   Bouncy Castle Provider under Bouncy Castle Licence
   Cryptacular Library under Apache 2 or GNU Lesser General Public License
+  Digipost JAXB Resolver - com.sun.xml.bind under The Apache Software License, Version 2.0
   Extended StAX API under Eclipse Distribution License - v 1.0
   Guava InternalFutureFailureAccess and InternalFutures under The Apache Software License, Version 2.0
   Guava: Google Core Libraries for Java under Apache License, Version 2.0
-  istack common utility code runtime under Eclipse Distribution License - v 1.0
-  Jakarta Activation under EDL 1.0
-  Jakarta Activation API jar under EDL 1.0
   Jakarta SOAP with Attachments API under Eclipse Distribution License - v 1.0
   Jakarta Web Services Metadata API under Eclipse Distribution License - v 1.0
-  Jakarta XML Binding API under Eclipse Distribution License - v 1.0
   Jakarta XML Web Services API under Eclipse Distribution License - v 1.0
   JASYPT: Java Simplified Encryption under The Apache Software License, Version 2.0
-  JAXB Runtime under Eclipse Distribution License - v 1.0
+  JavaBeans Activation Framework API jar under CDDL/GPLv2+CE
+  jaxb-api under CDDL 1.1 or GPL2 w/ CPE
   JAXB2 Basics - Runtime under BSD-Style License
   JCL 1.2 implemented over SLF4J under Apache License, Version 2.0
   Joda-Time under Apache License, Version 2.0
   MIME streaming extension under Eclipse Distribution License - v 1.0
+  Old JAXB Core under CDDL+GPL License
+  Old JAXB Runtime under Eclipse Distribution License - v 1.0
   saaj-impl under Eclipse Distribution License - v 1.0
   SDP Shared - XSD & JAXB under The Apache Software License, Version 2.0
   SLF4J API Module under MIT License
@@ -50,5 +50,4 @@ This software includes third party software subject to the following licenses:
   spring-ws-core under Apache License, Version 2.0
   spring-ws-security under Apache License, Version 2.0
   spring-xml under Apache License, Version 2.0
-  TXW2 Runtime under Eclipse Distribution License - v 1.0
 

--- a/api-commons/pom.xml
+++ b/api-commons/pom.xml
@@ -18,16 +18,16 @@
             <artifactId>saaj-impl</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.xml.soap</groupId>
             <artifactId>jakarta.xml.soap-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.activation</groupId>
-            <artifactId>jakarta.activation-api</artifactId>
+            <groupId>javax.activation</groupId>
+            <artifactId>javax.activation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.jws</groupId>

--- a/api-commons/pom.xml
+++ b/api-commons/pom.xml
@@ -88,7 +88,7 @@
 
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
+            <artifactId>bcprov-jdk18on</artifactId>
         </dependency>
 
         <!-- Spring -->

--- a/api-commons/pom.xml
+++ b/api-commons/pom.xml
@@ -16,28 +16,19 @@
         <dependency>
             <groupId>com.sun.xml.messaging.saaj</groupId>
             <artifactId>saaj-impl</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.xml.soap</groupId>
-            <artifactId>jakarta.xml.soap-api</artifactId>
+            <groupId>javax.xml.soap</groupId>
+            <artifactId>javax.xml.soap-api</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.activation</groupId>
             <artifactId>javax.activation-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.jws</groupId>
-            <artifactId>jakarta.jws-api</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.xml.ws</groupId>
-            <artifactId>jakarta.xml.ws-api</artifactId>
-            <scope>runtime</scope>
         </dependency>
 
         <dependency>
@@ -155,27 +146,22 @@
     </dependencies>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <configuration>
+                        <ignoredNonTestScopedDependencies>
+                            <ignored>javax.xml.soap:javax.xml.soap-api</ignored>
+                        </ignoredNonTestScopedDependencies>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.jasig.maven</groupId>
                 <artifactId>maven-notice-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>check-dependency-declarations-vs-usage</id>
-                        <goals>
-                            <goal>analyze-only</goal>
-                        </goals>
-                        <configuration>
-                            <ignoredUnusedDeclaredDependencies>com.sun.xml.messaging.saaj:saaj-impl</ignoredUnusedDeclaredDependencies>
-                            <ignoreNonCompile>true</ignoreNonCompile>
-                            <failOnWarning>true</failOnWarning>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -331,35 +331,35 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.3.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.1</version>
+                    <version>3.11.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M5</version>
+                    <version>3.0.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>3.0.0-M1</version>
+                    <version>3.1.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>3.0.0-M1</version>
+                    <version>3.1.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jasig.maven</groupId>
@@ -427,11 +427,11 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.8.1</version>
+                    <version>2.15.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.3.0</version>
                     <configuration>
                         <rules>
                             <bannedDependencies>
@@ -493,23 +493,19 @@
                                 </message>
                             </bannedDependencies>
                             <requireMavenVersion>
-                                <!-- Maven 3.3.1 is needed for .mvn/maven.config to work
-                                     https://maven.apache.org/docs/3.3.1/release-notes.html -->
-                                <version>3.3.1</version>
+                                <version>3.6.3</version>
                             </requireMavenVersion>
                         </rules>
                     </configuration>
                 </plugin>
                 <plugin>
-                    <artifactId>maven-release-plugin</artifactId>
-                    <version>2.5.3</version>
-                    <configuration>
-                        <releaseProfiles>release-update-submodules,build-sources-and-javadoc,sign-artifacts,git-push-reminder</releaseProfiles>
-                    </configuration>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
-                    <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>3.3.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -523,49 +519,16 @@
                             <goal>analyze-only</goal>
                         </goals>
                         <configuration>
-                            <ignoredUnusedDeclaredDependencies>com.sun.xml.messaging.saaj:saaj-impl</ignoredUnusedDeclaredDependencies>
                             <ignoreNonCompile>true</ignoreNonCompile>
                             <failOnWarning>true</failOnWarning>
+                            <ignoredNonTestScopedDependencies>
+                                <ignored>jakarta.xml.soap:jakarta.xml.soap-api</ignored>
+                            </ignoredNonTestScopedDependencies>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>release-update-submodules</id>
-            <activation>
-                <property>
-                    <name>performRelease</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <!-- This is a workaround to get submodules working with the maven release plugin -->
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <version>1.6.0</version>
-                        <executions>
-                            <execution>
-                                <inherited>false</inherited>
-                                <phase>initialize</phase>
-                                <id>invoke build</id>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <executable>updateSubmodules.sh</executable>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -229,6 +229,11 @@
                 </exclusions>
             </dependency>
             <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>31.1-jre</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.santuario</groupId>
                 <artifactId>xmlsec</artifactId>
                 <version>3.0.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.previousVersion>set_with_-Dproject.previousVersion=X.Y</project.previousVersion>
 
-        <org.slf4j.version>1.7.32</org.slf4j.version>
-        <spring.ws.version>3.1.4</spring.ws.version>
+        <org.slf4j.version>1.7.36</org.slf4j.version>
+        <spring.ws.version>3.1.5</spring.ws.version>
         <wss4j.version>2.3.2</wss4j.version>
         <jaxb2-basics.version>0.12.0</jaxb2-basics.version>
     </properties>
@@ -122,7 +122,7 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-framework-bom</artifactId>
-                <version>5.3.23</version>
+                <version>5.3.26</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -130,7 +130,7 @@
             <dependency>
                 <groupId>org.springframework.security</groupId>
                 <artifactId>spring-security-bom</artifactId>
-                <version>5.7.5</version>
+                <version>5.8.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -187,6 +187,10 @@
                         <groupId>javax.xml.ws</groupId>
                         <artifactId>jaxws-api</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>jakarta.xml.bind</groupId>
+                        <artifactId>jakarta.xml.bind-api</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -218,6 +222,10 @@
                         <groupId>org.bouncycastle</groupId>
                         <artifactId>bcprov-jdk15on</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>jakarta.xml.bind</groupId>
+                        <artifactId>jakarta.xml.bind-api</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -227,21 +235,15 @@
             </dependency>
 
             <dependency>
-                <groupId>jakarta.activation</groupId>
-                <artifactId>jakarta.activation-api</artifactId>
-                <version>1.2.2</version>
-            </dependency>
-
-            <dependency>
                 <groupId>jakarta.xml.soap</groupId>
                 <artifactId>jakarta.xml.soap-api</artifactId>
                 <version>1.4.2</version>
-            </dependency>
-
-            <dependency>
-                <groupId>jakarta.xml.bind</groupId>
-                <artifactId>jakarta.xml.bind-api</artifactId>
-                <version>2.3.3</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>jakarta.activation</groupId>
+                        <artifactId>jakarta.activation-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -253,6 +255,12 @@
                 <groupId>jakarta.xml.ws</groupId>
                 <artifactId>jakarta.xml.ws-api</artifactId>
                 <version>2.3.3</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>jakarta.xml.bind</groupId>
+                        <artifactId>jakarta.xml.bind-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.sun.xml.messaging.saaj</groupId>
@@ -263,14 +271,28 @@
                         <groupId>javax.xml.stream</groupId>
                         <artifactId>stax-api</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>jakarta.xml.bind</groupId>
+                        <artifactId>jakarta.xml.bind-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>jakarta.activation</groupId>
+                        <artifactId>jakarta.activation-api</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
             <dependency>
-                <groupId>org.glassfish.jaxb</groupId>
-                <artifactId>jaxb-runtime</artifactId>
-                <version>2.3.5</version>
-                <scope>runtime</scope>
+                <groupId>no.digipost</groupId>
+                <artifactId>jaxb-resolver-com.sun.xml.bind-bom</artifactId>
+                <version>1.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>javax.activation</groupId>
+                <artifactId>javax.activation-api</artifactId>
+                <version>1.2.0</version>
             </dependency>
 
             <dependency>
@@ -438,9 +460,8 @@
                                     <include>org.codehaus.woodstox:stax2-api</include>
                                     <include>com.fasterxml.woodstox:woodstox-core</include>
                                     <include>org.jasypt:jasypt</include>
-                                    <include>com.sun.xml.fastinfoset:FastInfoset</include>
-                                    <include>com.sun.istack:istack-commons-runtime</include>
-                                    <include>org.glassfish.jaxb:*</include>
+                                    <include>no.digipost:jaxb-resolver-com.sun.xml.bind</include>
+                                    <include>com.sun.xml.bind:*</include>
                                     <include>org.jvnet.jaxb2_commons:jaxb2-basics-runtime</include>
                                     <include>org.opensaml:*</include>
                                     <include>org.cryptacular:cryptacular</include>
@@ -452,13 +473,12 @@
                                     <include>org.springframework.security:*</include>
                                     <include>org.springframework.ws:*</include>
                                     <include>wsdl4j:wsdl4j</include>
-                                    <include>jakarta.activation:jakarta.activation-api</include>
+                                    <include>javax.activation:javax.activation-api</include>
                                     <include>com.sun.activation:jakarta.activation:jakarta.activation</include>
                                     <include>javax.xml.ws:jaxws-api</include>
                                     <include>javax.xml.bind:jaxb-api</include>
                                     <include>javax.annotation:javax.annotation-api</include>
                                     <include>javax.jws:jsr181-api</include>
-                                    <include>jakarta.xml.bind:jakarta.xml.bind-api</include>
                                     <include>jakarta.xml.soap:jakarta.xml.soap-api</include>
                                     <include>javax.xml.soap:javax.xml.soap-api</include>
                                     <include>com.sun.xml.messaging.saaj:saaj-impl</include>

--- a/pom.xml
+++ b/pom.xml
@@ -115,8 +115,8 @@
 
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk15on</artifactId>
-                <version>1.70</version>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>1.73</version>
             </dependency>
 
             <dependency>
@@ -213,6 +213,10 @@
                     <exclusion>
                         <groupId>org.apache.geronimo.javamail</groupId>
                         <artifactId>geronimo-javamail_1.4_mail</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>bcprov-jdk15on</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -430,7 +434,7 @@
                                     <include>org.apache.santuario:xmlsec</include>
                                     <include>org.apache.wss4j:wss4j-ws-security-common</include>
                                     <include>org.apache.wss4j:wss4j-ws-security-dom</include>
-                                    <include>org.bouncycastle:bcprov-jdk15on</include>
+                                    <include>org.bouncycastle:bcprov-jdk18on</include>
                                     <include>org.codehaus.woodstox:stax2-api</include>
                                     <include>com.fasterxml.woodstox:woodstox-core</include>
                                     <include>org.jasypt:jasypt</include>

--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,8 @@
         <project.previousVersion>set_with_-Dproject.previousVersion=X.Y</project.previousVersion>
 
         <org.slf4j.version>1.7.36</org.slf4j.version>
-        <spring.ws.version>3.1.5</spring.ws.version>
-        <wss4j.version>2.3.2</wss4j.version>
+        <spring.ws.version>3.1.6</spring.ws.version>
+        <wss4j.version>2.4.1</wss4j.version>
         <jaxb2-basics.version>0.12.0</jaxb2-basics.version>
     </properties>
 
@@ -184,12 +184,12 @@
                         <artifactId>ehcache</artifactId>
                     </exclusion>
                     <exclusion>
-                        <groupId>javax.xml.ws</groupId>
-                        <artifactId>jaxws-api</artifactId>
-                    </exclusion>
-                    <exclusion>
                         <groupId>jakarta.xml.bind</groupId>
                         <artifactId>jakarta.xml.bind-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>jakarta.xml.ws</groupId>
+                        <artifactId>jakarta.xml.ws-api</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -198,10 +198,6 @@
                 <artifactId>wss4j-ws-security-common</artifactId>
                 <version>${wss4j.version}</version>
                 <exclusions>
-                    <exclusion>
-                        <groupId>javax.xml.ws</groupId>
-                        <artifactId>jaxws-api</artifactId>
-                    </exclusion>
                     <exclusion>
                         <groupId>org.opensaml</groupId>
                         <artifactId>opensaml-saml-impl</artifactId>
@@ -226,6 +222,10 @@
                         <groupId>jakarta.xml.bind</groupId>
                         <artifactId>jakarta.xml.bind-api</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>jakarta.xml.ws</groupId>
+                        <artifactId>jakarta.xml.ws-api</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -235,38 +235,25 @@
             </dependency>
 
             <dependency>
-                <groupId>jakarta.xml.soap</groupId>
-                <artifactId>jakarta.xml.soap-api</artifactId>
-                <version>1.4.2</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>jakarta.activation</groupId>
-                        <artifactId>jakarta.activation-api</artifactId>
-                    </exclusion>
-                </exclusions>
+                <groupId>javax.xml.soap</groupId>
+                <artifactId>javax.xml.soap-api</artifactId>
+                <version>1.4.0</version>
             </dependency>
 
             <dependency>
-                <groupId>jakarta.jws</groupId>
-                <artifactId>jakarta.jws-api</artifactId>
-                <version>2.1.0</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.xml.ws</groupId>
-                <artifactId>jakarta.xml.ws-api</artifactId>
-                <version>2.3.3</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>jakarta.xml.bind</groupId>
-                        <artifactId>jakarta.xml.bind-api</artifactId>
-                    </exclusion>
-                </exclusions>
+                <groupId>javax.jws</groupId>
+                <artifactId>javax.jws-api</artifactId>
+                <version>1.1</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.xml.messaging.saaj</groupId>
                 <artifactId>saaj-impl</artifactId>
                 <version>1.5.1</version>
                 <exclusions>
+                    <exclusion>
+                        <groupId>jakarta.xml.soap</groupId>
+                        <artifactId>jakarta.xml.soap-api</artifactId>
+                    </exclusion>
                     <exclusion>
                         <groupId>javax.xml.stream</groupId>
                         <artifactId>stax-api</artifactId>
@@ -479,13 +466,12 @@
                                     <include>javax.xml.bind:jaxb-api</include>
                                     <include>javax.annotation:javax.annotation-api</include>
                                     <include>javax.jws:jsr181-api</include>
-                                    <include>jakarta.xml.soap:jakarta.xml.soap-api</include>
                                     <include>javax.xml.soap:javax.xml.soap-api</include>
                                     <include>com.sun.xml.messaging.saaj:saaj-impl</include>
                                     <include>org.jvnet.staxex:stax-ex</include>
                                     <include>org.jvnet.mimepull:mimepull</include>
-                                    <include>jakarta.jws:jakarta.jws-api</include>
-                                    <include>jakarta.xml.ws:jakarta.xml.ws-api</include>
+                                    <include>javax.jws:jakarta.jws-api</include>
+                                    <include>javax.xml.ws:javax.xml.ws-api</include>
                                 </includes>
                                 <searchTransitive>true</searchTransitive>
                                 <message>Maven-avhengigheter har forandret seg. Sjekk at alle lisenser er OK før
@@ -521,9 +507,6 @@
                         <configuration>
                             <ignoreNonCompile>true</ignoreNonCompile>
                             <failOnWarning>true</failOnWarning>
-                            <ignoredNonTestScopedDependencies>
-                                <ignored>jakarta.xml.soap:jakarta.xml.soap-api</ignored>
-                            </ignoredNonTestScopedDependencies>
                         </configuration>
                     </execution>
                 </executions>

--- a/xsd/NOTICE
+++ b/xsd/NOTICE
@@ -8,11 +8,10 @@ Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.html
 
 This software includes third party software subject to the following licenses:
 
-  istack common utility code runtime under Eclipse Distribution License - v 1.0
-  Jakarta Activation under EDL 1.0
-  Jakarta Activation API jar under EDL 1.0
-  Jakarta XML Binding API under Eclipse Distribution License - v 1.0
-  JAXB Runtime under Eclipse Distribution License - v 1.0
+  Digipost JAXB Resolver - com.sun.xml.bind under The Apache Software License, Version 2.0
+  JavaBeans Activation Framework API jar under CDDL/GPLv2+CE
+  jaxb-api under CDDL 1.1 or GPL2 w/ CPE
   JAXB2 Basics - Runtime under BSD-Style License
-  TXW2 Runtime under Eclipse Distribution License - v 1.0
+  Old JAXB Core under CDDL+GPL License
+  Old JAXB Runtime under Eclipse Distribution License - v 1.0
 

--- a/xsd/pom.xml
+++ b/xsd/pom.xml
@@ -74,7 +74,7 @@
 			<plugin>
 				<groupId>org.jvnet.jaxb2.maven2</groupId>
 				<artifactId>maven-jaxb2-plugin</artifactId>
-				<version>0.14.0</version>
+				<version>0.15.2</version>
 				<executions>
 					<execution>
 						<goals>

--- a/xsd/pom.xml
+++ b/xsd/pom.xml
@@ -19,18 +19,18 @@
 			<version>${jaxb2-basics.version}</version>
 		</dependency>
         <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jaxb</groupId>
-            <artifactId>jaxb-runtime</artifactId>
-            <scope>runtime</scope>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>no.digipost</groupId>
+            <artifactId>jaxb-resolver-com.sun.xml.bind</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/xsd/pom.xml
+++ b/xsd/pom.xml
@@ -55,7 +55,6 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
-				<version>3.0.0</version>
 				<executions>
 					<execution>
 						<id>include-xsd</id>


### PR DESCRIPTION
Mainly two changes:
- upgrade BouncyCastle
- eliminate jakarta-artifacts to avoid them being managed to newer versions in dependents on newer Java EE versions

The changes are tested with https://github.com/difi/sikker-digital-post-klient-java used in an application using Spring v6, Servlet Spec v5, other Jakarta stuff.