### PR TITLE
Manage nexus-staging-plugin to v1.6.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -498,6 +498,11 @@
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>3.3.0</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>1.6.13</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>


### PR DESCRIPTION
Needed to avoid:
```
Error:  Failed to execute goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.8:deploy (injected-nexus-deploy)
on project sdp-shared: 
Execution injected-nexus-deploy of goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.8:deploy failed:
An API incompatibility was encountered while executing
org.sonatype.plugins:nexus-staging-maven-plugin:1.6.8:deploy: java.lang.ExceptionInInitializerError: null
...
Unable to make field private final java.util.Comparator java.util.TreeMap.comparator accessible:
module java.base does not "opens java.util" to unnamed module @518bfd90
```