### PR TITLE
Bump guava dependency to 32.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>31.1-jre</version>
+                <version>32.0.1-jre</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.santuario</groupId>


### PR DESCRIPTION
Previous versions had a vulnerability (CVE-2023-2976)